### PR TITLE
Experiment with `map()` and lambdas

### DIFF
--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -1949,4 +1949,12 @@ defmodule Expression.Callbacks do
       _ -> false
     end
   end
+
+  def map(_ctx, enumerable, mapper) do
+    enumerable
+    # wrap in a list to be passed as a list of arguments
+    |> Enum.map(&[&1])
+    # call the mapper with each list of arguments as a single argument
+    |> Enum.map(mapper)
+  end
 end

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -62,8 +62,6 @@ defmodule Expression.Eval do
   end
 
   def eval!({:lambda, [{:args, ast}]}, context, mod) do
-    # IO.inspect(mapper.(1), label: "result?")
-    # IO.inspect(mapper, label: "mapper")
     fn arguments ->
       lambda_context = Map.put(context, "__captures", arguments)
 

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -61,13 +61,34 @@ defmodule Expression.Eval do
     end
   end
 
+  def eval!({:lambda, [{:args, ast}]}, context, mod) do
+    # IO.inspect(mapper.(1), label: "result?")
+    # IO.inspect(mapper, label: "mapper")
+    fn arguments ->
+      lambda_context = Map.put(context, "__captures", arguments)
+
+      [result] = eval!(ast, lambda_context, mod)
+      result
+    end
+  end
+
+  def eval!({:capture, index}, context, _mod) do
+    Enum.at(Map.get(context, "__captures"), index - 1)
+  end
+
   def eval!({:range, [first, last]}, _context, _mod),
     do: Range.new(first, last)
 
   def eval!({:range, [first, last, step]}, _context, _mod),
     do: Range.new(first, last, step)
 
-  def eval!({:list, [subject_ast, key_ast]}, context, mod) do
+  def eval!({:list, [{:args, ast}]}, context, mod) do
+    ast
+    |> Enum.reduce([], &[eval!(&1, context, mod) | &2])
+    |> Enum.reverse()
+  end
+
+  def eval!({:access, [subject_ast, key_ast]}, context, mod) do
     subject = eval!(subject_ast, context, mod)
     key = eval!(key_ast, context, mod)
 

--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -172,9 +172,7 @@ defmodule Expression.Parser do
   defparsec(
     :lambda,
     ignore(string("&"))
-    |> ignore(string("("))
     |> optional(parsec(:arguments) |> tag(:args))
-    |> ignore(string(")"))
     |> tag(:lambda)
   )
 

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -20,8 +20,6 @@ defmodule Expression.EvalTest do
   end
 
   describe "lambdas" do
-    @describetag :current
-
     test "with map" do
       {:ok, ast, "", _, _, _} = Parser.parse("@map(foo, &([&1,'Button']))")
       assert [result] = Eval.eval!(ast, %{"foo" => [1, 2, 3]})

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -19,6 +19,23 @@ defmodule Expression.EvalTest do
     assert [true] == Eval.eval!(ast, %{})
   end
 
+  describe "lambdas" do
+    @describetag :current
+
+    test "with map" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@map(foo, &([&1,'Button']))")
+      assert [result] = Eval.eval!(ast, %{"foo" => [1, 2, 3]})
+      assert result == [[1, "Button"], [2, "Button"], [3, "Button"]]
+    end
+
+    test "with arithmatic" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(map(foo, &([&1, 'Button'])))")
+
+      assert [result] = Eval.eval!(ast, %{"foo" => [1, 2, 3]})
+      assert result == [[1, "Button"], [2, "Button"], [3, "Button"]]
+    end
+  end
+
   test "email addresses" do
     {:ok, ast, "", _, _, _} = Parser.parse("email info@example.com for more information")
     assert ["email info", "@example.com", " for more information"] == Eval.eval!(ast, %{})

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -28,6 +28,17 @@ defmodule Expression.EvalTest do
       assert result == [[1, "Button"], [2, "Button"], [3, "Button"]]
     end
 
+    test "with functions" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@map(1..3, &date(2022, 5, &1))")
+      assert [result] = Eval.eval!(ast, %{})
+
+      assert result == [
+               ~U[2022-05-01 00:00:00Z],
+               ~U[2022-05-02 00:00:00Z],
+               ~U[2022-05-03 00:00:00Z]
+             ]
+    end
+
     test "with arithmatic" do
       {:ok, ast, "", _, _, _} = Parser.parse("@(map(foo, &([&1, 'Button'])))")
 

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -19,6 +19,28 @@ defmodule Expression.ParserTest do
     assert ast == produced_ast
   end
 
+  test "map" do
+    assert_ast(
+      [
+        {:expression,
+         [
+           function: [
+             name: "map",
+             args: [
+               atom: "foo",
+               lambda: [
+                 args: [
+                   list: [args: [capture: 1, atom: "button"]]
+                 ]
+               ]
+             ]
+           ]
+         ]}
+      ],
+      "@map(foo, &([&1,Button]))"
+    )
+  end
+
   describe "expression blocks" do
     test "variables" do
       assert_ast([expression: [atom: "foo"]], "@(foo)")

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -19,7 +19,7 @@ defmodule Expression.ParserTest do
     assert ast == produced_ast
   end
 
-  test "map" do
+  test "lambda" do
     assert_ast(
       [
         {:expression,
@@ -57,6 +57,19 @@ defmodule Expression.ParserTest do
       assert_ast(
         [expression: [literal: ~U[2022-05-24 00:00:00.0Z]]],
         "@(2022-05-24T00:00:00)"
+      )
+    end
+
+    test "lists" do
+      assert_ast(
+        [
+          expression: [
+            list: [
+              args: [literal: 1, atom: "foo", function: [name: "now"]]
+            ]
+          ]
+        ],
+        "@([1, foo, now()])"
       )
     end
 
@@ -188,24 +201,24 @@ defmodule Expression.ParserTest do
     end
   end
 
-  describe "lists" do
+  describe "access" do
     test "with integers" do
       assert_ast(
-        [expression: [list: [atom: "foo", literal: 0]]],
+        [expression: [access: [atom: "foo", literal: 0]]],
         "@foo[0]"
       )
     end
 
     test "with variables" do
       assert_ast(
-        [expression: [list: [atom: "foo", atom: "bar"]]],
+        [expression: [access: [atom: "foo", atom: "bar"]]],
         "@foo[bar]"
       )
     end
 
     test "with function call" do
       assert_ast(
-        [expression: [list: [atom: "foo", function: [name: "date"]]]],
+        [expression: [access: [atom: "foo", function: [name: "date"]]]],
         "@foo[date()]"
       )
     end
@@ -214,7 +227,7 @@ defmodule Expression.ParserTest do
       assert_ast(
         [
           expression: [
-            list: [
+            access: [
               atom: "foo",
               attribute: [
                 function: [name: "date"],


### PR DESCRIPTION
```
@(map(foo, &([&1, 'Button'])))
```

when context is `%{"foo" => [1, 2, 3]}` results in `[[1, "Button"], [2, "Button"], [3, "Button"]]` as the output.

within the context of the lambda, the `&1` captures are normal variables and so one can use them as arguments for other functions or operations like arithmetic:

```
@(map(foo, &([&1 * 2, 'Button'])))
```

Oh this also introduces lists as a type, bit of a side effect:

```elixir
iex(1)> Expression.evaluate("@([1,2,3])")
{:ok, [[1, 2, 3]]}
```

example use:

```
iex(7)> Expression.evaluate("@(map([1,2,3], &(&1 * 2)))")
{:ok, [[2, 4, 6]]}
```