### PR TITLE
Allow trailing full stops

### DIFF
--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -91,6 +91,7 @@ defmodule Expression.Parser do
   attribute =
     empty()
     |> ascii_char([?.])
+    |> lookahead(atom)
     |> replace(:attribute)
     |> label(".")
 

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -112,6 +112,11 @@ defmodule ExpressionTest do
       assert "user@example.org" = Expression.evaluate_as_string!("@('user' & '@example.org')")
     end
 
+    test "trailing full stops" do
+      assert "bar." = Expression.evaluate_as_string!("@foo.", %{"foo" => "bar"})
+      assert "baz." = Expression.evaluate_as_string!("@foo.bar.", %{"foo" => %{"bar" => "baz"}})
+    end
+
     test "substitution" do
       assert {:ok, ["hello ", "name"]} =
                Expression.evaluate("hello @(contact.name)", %{


### PR DESCRIPTION
Previously `Hello @contact.name.` would break because of the trailing full stop. 
This PR fixes that.