### PR TITLE
Fix key access

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -75,12 +75,15 @@ defmodule Expression do
     expression
     |> parse!
     |> Eval.eval!(Context.new(context), mod)
+    |> Enum.map(&default_value/1)
   end
 
   def evaluate_as_string!(expression, context \\ %{}, mod \\ Expression.Callbacks) do
     expression
     |> parse!
-    |> Eval.as_string!(Context.new(context), mod)
+    |> Eval.eval!(Context.new(context), mod)
+    |> Enum.map(&default_value/1)
+    |> Enum.map_join(&Kernel.to_string/1)
   end
 
   def evaluate_as_boolean!(expression, context \\ %{}, mod \\ Expression.Callbacks) do
@@ -92,6 +95,10 @@ defmodule Expression do
         raise "Expression #{inspect(expression)} did not return a boolean!, got #{inspect(other)} instead"
     end
   end
+
+  defp default_value(%{"__value__" => default_value}), do: default_value
+  defp default_value({:not_found, attributes}), do: "@#{Enum.join(attributes, ".")}"
+  defp default_value(value), do: value
 
   def evaluate(expression, context \\ %{}, mod \\ Expression.Callbacks) do
     {:ok, evaluate!(expression, context, mod)}

--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -99,8 +99,8 @@ defmodule Expression.Callbacks do
 
   # Example
 
-      iex> to_string(Expression.Callbacks.date(%{}, 2012, 12, 25))
-      "2012-12-25 00:00:00Z"
+      iex> Expression.evaluate!("@date(2012, 12, 15)")
+      [~U[2012-12-15 00:00:00Z]]
 
   """
   def date(_ctx, year, month, day) do
@@ -133,11 +133,11 @@ defmodule Expression.Callbacks do
 
   # Example
 
-      iex> date = Expression.Callbacks.date(%{}, 2020, 12, 20)
-      iex> Expression.Callbacks.datevalue(%{}, date)
-      "2020-12-20 00:00:00"
-      iex> Expression.Callbacks.datevalue(%{}, date, "%Y-%m-%d")
-      "2020-12-20"
+      iex> Expression.evaluate!("@datevalue(date(2020, 12, 20))")
+      ["2020-12-20 00:00:00"]
+      iex> Expression.evaluate!("@datevalue(date(2020, 12, 20), '%Y-%m-%d')")
+      ["2020-12-20"]
+
   """
   def datevalue(ctx, date, format \\ "%Y-%m-%d %H:%M:%S")
 

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -37,13 +37,11 @@ defmodule Expression.Eval do
     do: {:not_found, history ++ [atom]}
 
   def eval!({:atom, atom}, context, _mod) do
-    # get_in(context, [atom])
     Map.get(context, atom, {:not_found, [atom]})
   end
 
   def eval!({:attribute, ast}, context, mod) do
     Enum.reduce(ast, context, &eval!(&1, &2, mod))
-    # eval!({:attribute, ast}, context, mod)
   end
 
   def eval!({:function, opts}, context, mod) do

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -86,7 +86,7 @@ defmodule Expression.Eval do
     |> Enum.reverse()
   end
 
-  def eval!({:access, [subject_ast, key_ast]}, context, mod) do
+  def eval!({:key, [subject_ast, key_ast]}, context, mod) do
     subject = eval!(subject_ast, context, mod)
     key = eval!(key_ast, context, mod)
 

--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -98,13 +98,13 @@ defmodule Expression.Parser do
 
   defparsec(
     :key,
-    repeat(
-      ignore(ascii_char([91]))
-      |> replace(:"[")
-      |> parsec(:aexpr)
-      |> ignore(ascii_char([93]))
-      |> label("[..]")
-    )
+    # repeat(
+    ignore(ascii_char([91]))
+    |> replace(:"[")
+    |> parsec(:aexpr_exponent)
+    |> ignore(ascii_char([93]))
+    |> label("[..]")
+    # )
   )
 
   defparsec(
@@ -161,18 +161,26 @@ defmodule Expression.Parser do
   defparsec(
     :aexpr_exponent,
     parsec(:aexpr_factor)
-    |> optional(repeat(parsec(:attribute) |> parsec(:aexpr_factor)))
+    |> optional(
+      repeat(
+        choice([
+          parsec(:attribute) |> parsec(:aexpr_factor),
+          parsec(:key)
+        ])
+      )
+    )
     |> repeat(
       exponent()
       |> parsec(:aexpr_factor)
       |> optional(
         repeat(
-          parsec(:attribute)
-          |> parsec(:aexpr_factor)
+          choice([
+            parsec(:attribute) |> parsec(:aexpr_factor),
+            parsec(:key)
+          ])
         )
       )
     )
-    |> optional(parsec(:key))
     |> reduce(:fold_infixl)
 
     # |> reduce(:fold_infixl)

--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -117,6 +117,14 @@ defmodule Expression.Parser do
       ])
     )
 
+  # The difference between this one and the one above
+  # is that this one does not allow for spaces or arithmatic
+  # which makes it suitable for use in `@foo` type expressions
+  # because otherwise `info@support.com for` (note the space)
+  # is parsed as being part of the expression.
+  #
+  # That would be wrong since spaces are only allowed in
+  # expressions starting with brackets like `@( ... )`
   attribute_or_key_with_primitives_only =
     repeat(
       choice([

--- a/lib/operator_helpers.ex
+++ b/lib/operator_helpers.ex
@@ -2,15 +2,6 @@ defmodule Expression.OperatorHelpers do
   @moduledoc false
   import NimbleParsec
 
-  def key(combinator \\ empty()) do
-    combinator
-    |> ascii_char([91])
-    |> parsec(:aexpr)
-    |> ascii_char([93])
-    |> reduce(:fold_infixl)
-    |> tag(:key)
-  end
-
   def plus(combinator \\ empty()), do: combinator |> ascii_char([?+]) |> replace(:+) |> label("+")
 
   def minus(combinator \\ empty()),
@@ -28,13 +19,6 @@ defmodule Expression.OperatorHelpers do
   def exponent(combinator \\ empty()),
     do: combinator |> ascii_char([?^]) |> replace(:^) |> label("^")
 
-  [
-    "#": [atom: "foo", atom: "a"],
-    "#": [[], {:atom, "b"}],
-    "#": [[], {:atom, "c"}]
-  ]
-
-  [.: [atom: "foo", .: [atom: "a", .: [atom: "b", atom: "c"]]]]
   def gte(combinator \\ empty()), do: combinator |> string(">=") |> replace(:>=) |> label(">=")
   def lte(combinator \\ empty()), do: combinator |> string("<=") |> replace(:<=) |> label("<=")
 

--- a/lib/operator_helpers.ex
+++ b/lib/operator_helpers.ex
@@ -2,6 +2,15 @@ defmodule Expression.OperatorHelpers do
   @moduledoc false
   import NimbleParsec
 
+  def key(combinator \\ empty()) do
+    combinator
+    |> ascii_char([91])
+    |> parsec(:aexpr)
+    |> ascii_char([93])
+    |> reduce(:fold_infixl)
+    |> tag(:key)
+  end
+
   def plus(combinator \\ empty()), do: combinator |> ascii_char([?+]) |> replace(:+) |> label("+")
 
   def minus(combinator \\ empty()),
@@ -19,6 +28,13 @@ defmodule Expression.OperatorHelpers do
   def exponent(combinator \\ empty()),
     do: combinator |> ascii_char([?^]) |> replace(:^) |> label("^")
 
+  [
+    "#": [atom: "foo", atom: "a"],
+    "#": [[], {:atom, "b"}],
+    "#": [[], {:atom, "c"}]
+  ]
+
+  [.: [atom: "foo", .: [atom: "a", .: [atom: "b", atom: "c"]]]]
   def gte(combinator \\ empty()), do: combinator |> string(">=") |> replace(:>=) |> label(">=")
   def lte(combinator \\ empty()), do: combinator |> string("<=") |> replace(:<=) |> label("<=")
 

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -45,7 +45,6 @@ defmodule Expression.EvalTest do
     end
   end
 
-  # @tag :skip
   test "email addresses" do
     {:ok, ast, "", _, _, _} = Parser.parse("email info@example.com for more information")
     assert ["email info", "@example.com", " for more information"] == Eval.eval!(ast, %{})

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -4,19 +4,17 @@ defmodule Expression.EvalTest do
   alias Expression.Parser
 
   test "substitution" do
-    {:ok, ast, "", _, _, _} = Parser.parse("@foo")
-    assert "bar" == Eval.as_string!(ast, %{"foo" => "bar"})
+    assert "bar" == Expression.evaluate_as_string!("@foo", %{"foo" => "bar"})
   end
 
   test "attributes on substitutions" do
-    {:ok, ast, "", _, _, _} = Parser.parse("@foo.bar")
-    assert "baz" == Eval.as_string!(ast, %{"foo" => %{"bar" => "baz"}})
+    assert "baz" == Expression.evaluate_as_string!("@foo.bar", %{"foo" => %{"bar" => "baz"}})
   end
 
   test "functions" do
     {:ok, ast, "", _, _, _} = Parser.parse(~s[@has_any_word("The Quick Brown Fox", "red fox")])
 
-    assert [true] == Eval.eval!(ast, %{})
+    assert [%{"__value__" => true, "match" => "Fox"}] == Eval.eval!(ast, %{})
   end
 
   describe "lambdas" do
@@ -46,15 +44,19 @@ defmodule Expression.EvalTest do
   end
 
   test "email addresses" do
-    {:ok, ast, "", _, _, _} = Parser.parse("email info@example.com for more information")
-    assert ["email info", "@example.com", " for more information"] == Eval.eval!(ast, %{})
+    assert "email info@one.two.three.four.five.six for more information" ==
+             Expression.evaluate_as_string!(
+               "email info@one.two.three.four.five.six for more information",
+               %{}
+             )
   end
 
   test "attributes on functions" do
-    {:ok, ast, "", _, _, _} =
-      Parser.parse(~s[@has_any_word("The Quick Brown Fox", "red fox").match])
-
-    assert "Fox" == Eval.as_string!(ast, %{})
+    assert "Fox" ==
+             Expression.evaluate_as_string!(
+               ~s[@has_any_word("The Quick Brown Fox", "red fox").match],
+               %{}
+             )
   end
 
   describe "lists" do
@@ -90,7 +92,9 @@ defmodule Expression.EvalTest do
   end
 
   test "text" do
-    {:ok, ast, "", _, _, _} = Parser.parse("hello @contact.name")
-    assert "hello Bob" == Eval.as_string!(ast, %{"contact" => %{"name" => "Bob"}})
+    assert "hello Bob" ==
+             Expression.evaluate_as_string!("hello @contact.name", %{
+               "contact" => %{"name" => "Bob"}
+             })
   end
 end

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -45,6 +45,7 @@ defmodule Expression.EvalTest do
     end
   end
 
+  # @tag :skip
   test "email addresses" do
     {:ok, ast, "", _, _, _} = Parser.parse("email info@example.com for more information")
     assert ["email info", "@example.com", " for more information"] == Eval.eval!(ast, %{})

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -202,6 +202,24 @@ defmodule Expression.ParserTest do
   end
 
   describe "access" do
+    test "as function arguments" do
+      assert_ast(
+        [
+          expression: [
+            function: [
+              name: "if",
+              args: [
+                access: [atom: "record", atom: "a"],
+                access: [atom: "record", atom: "a"],
+                literal: ""
+              ]
+            ]
+          ]
+        ],
+        "@if(record[a], record[a], \"\")"
+      )
+    end
+
     test "with integers" do
       assert_ast(
         [expression: [access: [atom: "foo", literal: 0]]],

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -209,8 +209,8 @@ defmodule Expression.ParserTest do
             function: [
               name: "if",
               args: [
-                access: [atom: "record", atom: "a"],
-                access: [atom: "record", atom: "a"],
+                key: [atom: "record", atom: "a"],
+                key: [atom: "record", atom: "a"],
                 literal: ""
               ]
             ]
@@ -222,21 +222,21 @@ defmodule Expression.ParserTest do
 
     test "with integers" do
       assert_ast(
-        [expression: [access: [atom: "foo", literal: 0]]],
+        [expression: [key: [atom: "foo", literal: 0]]],
         "@foo[0]"
       )
     end
 
     test "with variables" do
       assert_ast(
-        [expression: [access: [atom: "foo", atom: "bar"]]],
+        [expression: [key: [atom: "foo", atom: "bar"]]],
         "@foo[bar]"
       )
     end
 
     test "with function call" do
       assert_ast(
-        [expression: [access: [atom: "foo", function: [name: "date"]]]],
+        [expression: [key: [atom: "foo", function: [name: "date"]]]],
         "@foo[date()]"
       )
     end
@@ -245,7 +245,7 @@ defmodule Expression.ParserTest do
       assert_ast(
         [
           expression: [
-            access: [
+            key: [
               atom: "foo",
               attribute: [
                 function: [name: "date"],

--- a/test/expression_callbacks_test.exs
+++ b/test/expression_callbacks_test.exs
@@ -1,4 +1,4 @@
 defmodule ExpressionCallbacksTest do
   use ExUnit.Case
-  doctest Expression.Callbacks
+  doctest Expression.Callbacks, import: true
 end

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -207,15 +207,15 @@ defmodule ExpressionTest do
     end
 
     test "return an error tuple when variables are not defined" do
-      assert {:error, "expression is not a number: `\"@block.value\"`"} =
+      assert {:error, "attribute is not found: `value`"} =
                Expression.evaluate_block("block.value > 0", %{"block" => %{}})
 
-      assert {:error, "expression is not a number: `\"@block.value\"`"} =
+      assert {:error, "attribute is not found: `block.value`"} =
                Expression.evaluate_block("block.value > 0", %{})
     end
 
     test "throw an error when variables are not defined" do
-      assert_raise RuntimeError, "expression is not a number: `\"@block.value\"`", fn ->
+      assert_raise RuntimeError, "attribute is not found: `value`", fn ->
         Expression.evaluate_block!("block.value > 0", %{"block" => %{}})
       end
     end


### PR DESCRIPTION
`@IF(record[foo], record[foo], "")` was failing because the `[` and `]` access keys weren't accepted in function arguments.