### PR TITLE
Fix attribute literal keys

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -40,6 +40,20 @@ defmodule Expression.Eval do
     Map.get(context, atom, {:not_found, [atom]})
   end
 
+  def eval!({:attribute, [{:attribute, ast}, literal: literal]}, context, mod) do
+    # When we receive a key for an attribute, at times this could be a literal.
+    # The assumption is that all attributes are going to be string based so if we receive
+    # "@foo.123.bar", `123` will be parsed as a literal but the assumption is that the
+    # context will look like:
+    #
+    # %{"foo" => %{
+    #   "123" => %{   <--- notice the string key here
+    #     "bar" => "the value"
+    #   }
+    # }}
+    eval!({:attribute, [{:attribute, ast}, atom: to_string(literal)]}, context, mod)
+  end
+
   def eval!({:attribute, ast}, context, mod) do
     Enum.reduce(ast, context, &eval!(&1, &2, mod))
   end

--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -78,8 +78,8 @@ defmodule Expression.Parser do
       lambda_capture,
       range,
       parsec(:lambda),
-      parsec(:literal),
       parsec(:function),
+      parsec(:literal),
       parsec(:variable),
       parsec(:list)
     ])

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -11,6 +11,19 @@ defmodule Expression.EvalTest do
     assert "baz" == Expression.evaluate_as_string!("@foo.bar", %{"foo" => %{"bar" => "baz"}})
   end
 
+  test "attributes with literals" do
+    assert "value" ==
+             Expression.evaluate_as_string!("@foo.bar.123.baz", %{
+               "foo" => %{
+                 "bar" => %{
+                   "123" => %{
+                     "baz" => "value"
+                   }
+                 }
+               }
+             })
+  end
+
   test "functions" do
     {:ok, ast, "", _, _, _} = Parser.parse(~s[@has_any_word("The Quick Brown Fox", "red fox")])
 

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -85,10 +85,11 @@ defmodule Expression.ParserTest do
         [
           expression: [
             attribute: [
-              function: [
-                {:name, "now"},
-                {:args, [literal: 1]}
-              ],
+              {:function,
+               [
+                 {:name, "now"},
+                 {:args, [literal: 1]}
+               ]},
               atom: "year"
             ]
           ]
@@ -238,6 +239,20 @@ defmodule Expression.ParserTest do
       assert_ast(
         [expression: [key: [atom: "foo", function: [name: "date"]]]],
         "@foo[date()]"
+      )
+    end
+
+    test "with literals as keys" do
+      assert_ast(
+        [
+          expression: [
+            attribute: [
+              attribute: [attribute: [atom: "foo", atom: "bar"], literal: 123],
+              atom: "baz"
+            ]
+          ]
+        ],
+        "@foo.bar.123.baz"
       )
     end
 


### PR DESCRIPTION
When we receive a key for an attribute, at times this could be a literal.
The assumption is that all attributes are going to be string based so if we receive
`@foo.123.bar`, `123` will be parsed as a literal but the assumption is that the
context will look like:

```elixir
%{"foo" => %{
  "123" => %{   <--- notice the string key here
    "bar" => "the value"
  }
}}
```