### PR TITLE
Allow white space in function arguments

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -47,6 +47,9 @@ defmodule Expression do
 
       {:ok, _ast, remainder, _, _, _} ->
         raise "Unable to parse: #{inspect(remainder)}"
+
+      {:error, reason, problematic, _, _, _} ->
+        raise "#{reason} in #{inspect(problematic)}"
     end
   end
 

--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -50,15 +50,17 @@ defmodule Expression.Parser do
     )
     |> tag(:range)
 
+  whitespace = choice([string(" "), string("\n"), string("\r")])
+
   ignore_surrounding_whitespace = fn p ->
-    ignore(optional(string(" ")))
+    ignore(repeat(whitespace))
     |> concat(p)
-    |> ignore(optional(string(" ")))
+    |> ignore(repeat(whitespace))
   end
 
   # argument separator = ", "
   argument_separator =
-    repeat(choice([string("\n"), string("\r"), string(",")]))
+    string(",")
     |> ignore_surrounding_whitespace.()
 
   lambda_capture =

--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -58,7 +58,7 @@ defmodule Expression.Parser do
 
   # argument separator = ", "
   argument_separator =
-    string(",")
+    repeat(choice([string("\n"), string("\r"), string(",")]))
     |> ignore_surrounding_whitespace.()
 
   lambda_capture =

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -107,6 +107,13 @@ defmodule Expression.ParserTest do
       )
     end
 
+    test "functions with white space" do
+      assert_ast(
+        [expression: [function: [name: "now", args: [literal: 1, literal: 2, literal: 3]]]],
+        "@(now(1,\n   2,\n3))"
+      )
+    end
+
     test "attributes" do
       assert_ast(
         [


### PR DESCRIPTION
Allow for 
```elixir
@function(1,
          2,
          3)
```