### PR TITLE
Stringify primitives properly

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -99,8 +99,13 @@ defmodule Expression do
     end
   end
 
+  defp stringify(items) when is_list(items), do: Enum.map_join(items, ", ", &to_string/1)
   defp stringify(binary) when is_binary(binary), do: binary
-  defp stringify(items) when is_list(items), do: Enum.map_join(items, "", &to_string/1)
+  defp stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)
+  defp stringify(%Date{} = date), do: Date.to_iso8601(date)
+  defp stringify(%Decimal{} = decimal), do: Decimal.to_string(decimal, :normal)
+  defp stringify(other), do: to_string(other)
+
   defp default_value(val, opts \\ [])
   defp default_value(%{"__value__" => default_value}, _opts), do: default_value
 

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -99,7 +99,7 @@ defmodule Expression do
     end
   end
 
-  defp stringify(items) when is_list(items), do: Enum.map_join(items, "", &to_string/1)
+  defp stringify(items) when is_list(items), do: Enum.map_join(items, "", &stringify/1)
   defp stringify(binary) when is_binary(binary), do: binary
   defp stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)
   defp stringify(%Date{} = date), do: Date.to_iso8601(date)

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -99,7 +99,7 @@ defmodule Expression do
     end
   end
 
-  defp stringify(items) when is_list(items), do: Enum.map_join(items, ", ", &to_string/1)
+  defp stringify(items) when is_list(items), do: Enum.map_join(items, "", &to_string/1)
   defp stringify(binary) when is_binary(binary), do: binary
   defp stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)
   defp stringify(%Date{} = date), do: Date.to_iso8601(date)

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -25,6 +25,16 @@ defmodule ExpressionTest do
                })
     end
 
+    test "stringify primitives" do
+      assert iso_dt = Expression.evaluate_as_string!("@NOW()")
+      assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(iso_dt)
+      assert "true" == Expression.evaluate_as_string!("@(tRuE)")
+      assert "false" == Expression.evaluate_as_string!("@(FaLsE)")
+      assert "1.23" == Expression.evaluate_as_string!("@(1.23)")
+      assert "2022-06-28T00:00:00Z" == Expression.evaluate_as_string!("@date(2022, 6, 28)")
+      assert "1, 2, 3" == Expression.evaluate_as_string!("@([1,2,3])")
+    end
+
     test "list with attribute" do
       assert "bar" =
                Expression.evaluate_as_string!("@foo[0].name", %{"foo" => [%{"name" => "bar"}]})

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -32,7 +32,7 @@ defmodule ExpressionTest do
       assert "false" == Expression.evaluate_as_string!("@(FaLsE)")
       assert "1.23" == Expression.evaluate_as_string!("@(1.23)")
       assert "2022-06-28T00:00:00Z" == Expression.evaluate_as_string!("@date(2022, 6, 28)")
-      assert "1, 2, 3" == Expression.evaluate_as_string!("@([1,2,3])")
+      assert "123" == Expression.evaluate_as_string!("@([1,2,3])")
     end
 
     test "list with attribute" do


### PR DESCRIPTION
Expressions know of a few primitives but they'd break when we tried to display them as strings.