### PR TITLE
Allow for strings as keys in maps

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -100,6 +100,7 @@ defmodule Expression.Eval do
     case key do
       index when is_number(index) -> get_in(subject, [Access.at(index)])
       range when is_struct(range, Range) -> Enum.slice(subject, range)
+      binary when is_binary(binary) -> Map.get(subject, binary)
     end
   end
 

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -108,6 +108,12 @@ defmodule Expression.EvalTest do
       assert 1 == Eval.eval!(ast, %{"foo" => %{"a" => 1}, "bar" => "a"})
     end
 
+    test "with binary keys as variables and strings" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@foo[bar]['baz']")
+
+      assert 1 == Eval.eval!(ast, %{"foo" => %{"a" => %{"baz" => 1}}, "bar" => "a"})
+    end
+
     test "with function" do
       {:ok, ast, "", _, _, _} = Parser.parse("@foo[day(now())]")
       today = DateTime.utc_now().day

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -90,10 +90,22 @@ defmodule Expression.EvalTest do
   end
 
   describe "lists" do
-    test "with literal indices" do
+    test "with integer indices" do
       {:ok, ast, "", _, _, _} = Parser.parse("@foo[1]")
 
       assert 1 == Eval.eval!(ast, %{"foo" => [0, 1, 2]})
+    end
+
+    test "with binary keys" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@foo['a']")
+
+      assert 1 == Eval.eval!(ast, %{"foo" => %{"a" => 1}})
+    end
+
+    test "with binary keys as variables" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@foo[bar]")
+
+      assert 1 == Eval.eval!(ast, %{"foo" => %{"a" => 1}, "bar" => "a"})
     end
 
     test "with function" do


### PR DESCRIPTION
Expressions like `@foo["bar"]` were failing