### PR TITLE
Auto generate docs samples + doc tests

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -99,12 +99,12 @@ defmodule Expression do
     end
   end
 
-  defp stringify(items) when is_list(items), do: Enum.map_join(items, "", &stringify/1)
-  defp stringify(binary) when is_binary(binary), do: binary
-  defp stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)
-  defp stringify(%Date{} = date), do: Date.to_iso8601(date)
-  defp stringify(%Decimal{} = decimal), do: Decimal.to_string(decimal, :normal)
-  defp stringify(other), do: to_string(other)
+  def stringify(items) when is_list(items), do: Enum.map_join(items, "", &stringify/1)
+  def stringify(binary) when is_binary(binary), do: binary
+  def stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)
+  def stringify(%Date{} = date), do: Date.to_iso8601(date)
+  def stringify(%Decimal{} = decimal), do: Decimal.to_string(decimal, :normal)
+  def stringify(other), do: to_string(other)
 
   defp default_value(val, opts \\ [])
   defp default_value(%{"__value__" => default_value}, _opts), do: default_value

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -36,6 +36,14 @@ defmodule Expression do
   ```
 
   """
+
+  @type expression_type ::
+          String.t()
+          | number
+          | DateTime.t()
+          | Date.t()
+          | Decimal.t()
+
   alias Expression.Context
   alias Expression.Eval
   alias Expression.Parser
@@ -99,6 +107,12 @@ defmodule Expression do
     end
   end
 
+  @doc """
+  Convert an Expression type into a string.
+
+  This function is applied to all values when `Expression.evaluate_as_string!/3` is called.
+  """
+  @spec stringify([expression_type] | expression_type) :: String.t()
   def stringify(items) when is_list(items), do: Enum.map_join(items, "", &stringify/1)
   def stringify(binary) when is_binary(binary), do: binary
   def stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -76,7 +76,7 @@ defmodule Expression.Autodoc do
         When used as a Stack expression it returns a #{format_result(expression_doc[:result])}#{format_context(expression_doc[:context])}.
 
         ```
-        #{expression_doc[:expression]}
+        #{expression_doc[:expression]} -> #{inspect(expression_doc[:result])}
         ```
 
         When used as an expression in text, prepend it with an `@`:
@@ -124,6 +124,9 @@ defmodule Expression.Autodoc do
 
   def type_of(%Date{}), do: "Date"
   def type_of(%DateTime{}), do: "DateTime"
+  def type_of(%Decimal{}), do: "Decimal"
+  def type_of(integer) when is_integer(integer), do: "Integer"
+  def type_of(float) when is_float(float), do: "Float"
   def type_of(binary) when is_binary(binary), do: "String"
 
   def stringify(%{"__value__" => value}), do: Expression.stringify(value)

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -71,7 +71,14 @@ defmodule Expression.Autodoc do
         #{expression_doc[:doc]}
 
         ```expression
-        #{expression_doc[:expression]}
+        > #{expression_doc[:expression]}
+        "#{expression_doc[:result]}"
+        ```
+
+        when given the context:
+
+        ```elixir
+        #{inspect(expression_doc[:context])}
         ```
 
         ## Example code:

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -1,0 +1,97 @@
+defmodule Expression.Autodoc do
+  defmacro __using__(_args) do
+    quote do
+      @expression_docs []
+      Module.register_attribute(__MODULE__, :expression_doc, accumulate: true)
+      @on_definition Expression.Autodoc
+      @before_compile Expression.Autodoc
+
+      import Expression.Autodoc
+      require Expression.Autodoc
+    end
+  end
+
+  def __on_definition__(env, _kind, name, args, _guards, _body) do
+    annotate_method(env.module, name, args)
+  end
+
+  def annotate_method(module, function, args) do
+    if expression_doc = Module.delete_attribute(module, :expression_doc) do
+      update_annotations(module, function, args, expression_doc)
+    end
+  end
+
+  def update_annotations(_module, _function, _args, []), do: nil
+
+  def update_annotations(module, function, args, expression_docs) do
+    existing_expression_docs = Module.get_attribute(module, :expression_docs)
+
+    for expression_doc <- expression_docs do
+      {line_number, doc} =
+        case Module.get_attribute(module, :doc) do
+          {line_number, doc} -> {line_number, doc}
+          nil -> {0, ""}
+        end
+
+      Module.put_attribute(
+        module,
+        :doc,
+        {line_number,
+         """
+         #{doc}
+
+         ## Example expression:
+
+         #{expression_doc[:doc]}
+
+         ```expression
+         #{expression_doc[:expression]}
+         ```
+
+         ## Example code:
+
+             iex> Expression.evaluate_as_string!(
+             ...>   #{inspect(expression_doc[:expression])},
+             ...>   #{inspect(expression_doc[:context])}
+             ...> )
+             #{inspect(expression_doc[:result])}
+
+         """}
+      )
+    end
+
+    Module.put_attribute(module, :expression_docs, [
+      {format_function_name(function), format_function_args(args), format_docs(expression_docs)}
+      | existing_expression_docs
+    ])
+  end
+
+  def format_function_name(name) do
+    name = to_string(name)
+
+    cond do
+      String.ends_with?(name, "_vargs") -> String.trim_trailing("_vargs")
+      String.ends_with?(name, "_") -> String.trim_trailing("_")
+      true -> name
+    end
+  end
+
+  def format_function_args(args) do
+    args
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.reject(&(&1 == :ctx))
+    |> Enum.map(&to_string/1)
+  end
+
+  def format_docs(docs) do
+    Enum.map(docs, &Enum.into(&1, %{}))
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      def expression_docs do
+        @expression_docs
+      end
+    end
+  end
+end

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -63,7 +63,7 @@ defmodule Expression.Autodoc do
     {line_number, doc} = get_existing_docstring(module)
 
     expression_doc_tests =
-      Enum.map(expression_docs, fn expression_doc ->
+      Enum.map_join(expression_docs, "\n", fn expression_doc ->
         """
         ## Example expression:
 
@@ -83,7 +83,6 @@ defmodule Expression.Autodoc do
 
         """
       end)
-      |> Enum.join("\n")
 
     updated_docs =
       case doc do

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -7,6 +7,22 @@ defmodule Expression.Autodoc do
   Also inserts an `expression_docs()` function which returns a list of
   all functions and their defined expression docs.
 
+  The format is:
+
+  ```elixir
+  @expression_doc doc: "Construct a date from year, month, and day integers",
+                  expression: "@date(year, month, day)",
+                  context: %{"year" => 2022, "month" => 1, "day" => 31},
+                  result: "2022-01-31T00:00:00Z"
+  ```
+
+  Where:
+
+  * `doc` is the explanatory text added to the doctest.
+  * `expression` is the expression we want to test
+  * `context` is the context the expression is tested against
+  * `result` is the result we're expecting to get and are asserting against
+
   """
   defmacro __using__(_args) do
     quote do

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -1,4 +1,13 @@
 defmodule Expression.Autodoc do
+  @moduledoc """
+
+  Extract `@expression_doc` attributes from modules defining callbacks
+  and automatically write doctests for those.
+
+  Also inserts an `expression_docs()` function which returns a list of
+  all functions and their defined expression docs.
+
+  """
   defmacro __using__(_args) do
     quote do
       @expression_docs []
@@ -89,6 +98,9 @@ defmodule Expression.Autodoc do
 
   defmacro __before_compile__(_env) do
     quote do
+      @doc """
+      Return a list of all functions annotated with @expression_docs
+      """
       def expression_docs do
         @expression_docs
       end

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -36,7 +36,6 @@ defmodule Expression.Autodoc do
       @before_compile Expression.Autodoc
 
       import Expression.Autodoc
-      require Expression.Autodoc
     end
   end
 

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -70,24 +70,37 @@ defmodule Expression.Autodoc do
 
         #{expression_doc[:doc]}
 
-        ```expression
-        > #{expression_doc[:expression]}
-        "#{expression_doc[:result]}"
-        ```
-
-        when given the context:
+        When used as a Stack expression with context:
 
         ```elixir
         #{inspect(expression_doc[:context])}
         ```
 
+        ```elixir
+        > #{expression_doc[:expression]}
+        #{inspect(expression_doc[:result])}
+        ```
+
+        When used as an expression in text:
+
+        ```expression
+        > "... @#{expression_doc[:expression]} ..."
+        "#{Expression.stringify(expression_doc[:result])}"
+        ```
+
         ## Example code:
 
-            iex> Expression.evaluate_as_string!(
+            iex> Expression.evaluate_block!(
             ...>   #{inspect(expression_doc[:expression])},
             ...>   #{inspect(expression_doc[:context])}
             ...> )
             #{inspect(expression_doc[:result])}
+
+            iex> Expression.evaluate_as_string!(
+            ...>   #{inspect("@" <> expression_doc[:expression])},
+            ...>   #{inspect(expression_doc[:context])}
+            ...> )
+            #{inspect(Expression.stringify(expression_doc[:result]))}
 
         """
       end)

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -73,7 +73,7 @@ defmodule Expression.Autodoc do
 
           > #{expression_doc[:doc]}
 
-        When used as a Stack expression it returns a #{format_result(expression_doc[:result])}#{format_context(expression_doc[:context])}.
+        When used as a Stack expression it returns a #{format_result(expression_doc[:result])}#{format_context(expression_doc[:context])}
 
         ```
         #{expression_doc[:expression]} -> #{inspect(expression_doc[:result])}
@@ -156,17 +156,17 @@ defmodule Expression.Autodoc do
     """
   end
 
-  def format_result(result), do: "**#{type_of(result)}** type: `#{inspect(result)}`"
+  def format_result(result), do: " *#{type_of(result)}** type: `#{inspect(result)}`."
 
-  def format_context(nil), do: ""
+  def format_context(nil), do: "."
 
   def format_context(context) do
     """
-    when used with the following context:
+     when used with the following context:
 
     ```elixir
     #{inspect(context)}
-    ```
+    ```.
     """
   end
 

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -70,18 +70,20 @@ defmodule Expression.Autodoc do
 
         #{expression_doc[:doc]}
 
-        When used as a Stack expression with context:
+        When used as a Stack expression
+
+        ```
+        #{expression_doc[:expression]}
+        ```
+
+        it returns `#{inspect(expression_doc[:result])}` of type `#{type_of(expression_doc[:result])}` when used
+        with the following context:
 
         ```elixir
         #{inspect(expression_doc[:context])}
         ```
 
-        ```elixir
-        > #{expression_doc[:expression]}
-        #{inspect(expression_doc[:result])}
-        ```
-
-        When used as an expression in text:
+        When used as an expression in text, prepend it with an `@`:
 
         ```expression
         > "... @#{expression_doc[:expression]} ..."
@@ -123,6 +125,8 @@ defmodule Expression.Autodoc do
       | existing_expression_docs
     ])
   end
+
+  def type_of(%DateTime{}), do: "DateTime"
 
   def get_existing_docstring(module) do
     case Module.get_attribute(module, :doc) do

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -36,9 +36,10 @@ defmodule Expression.Autodoc do
     end
   end
 
-  def __on_definition__(env, _kind, name, args, _guards, _body) do
-    annotate_method(env.module, name, args)
-  end
+  def __on_definition__(env, :def, name, args, _guards, _body),
+    do: annotate_method(env.module, name, args)
+
+  def __on_definition__(_env, _kind, _name, _args, _guards, _body), do: nil
 
   def annotate_method(module, function, args) do
     if expression_doc = Module.delete_attribute(module, :expression_doc) do

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -25,7 +25,6 @@ defmodule Expression.Callbacks.Standard do
   use Expression.Autodoc
 
   @punctuation_pattern ~r/\s*[,:;!?.-]\s*|\s/
-
   @doc """
   Defines a new date value
   """
@@ -203,7 +202,7 @@ defmodule Expression.Callbacks.Standard do
                   expression: "minute(now())",
                   result: DateTime.utc_now().minute
   def minute(ctx, date) do
-    %{minute: minute} = eval!(date, ctx)
+    %{minute: minute} = extract_datetimeish(eval!(date, ctx))
     minute
   end
 
@@ -224,13 +223,6 @@ defmodule Expression.Callbacks.Standard do
   ```
   It is currently @NOW()
   ```
-
-  # Example
-
-      iex> now = DateTime.utc_now()
-      iex> eval_now = Expression.evaluate!("@now()")
-      iex> DateTime.to_unix(eval_now) - DateTime.to_unix(now) in [0, 1]
-      true
   """
   @expression_doc doc: "return the current timestamp as a DateTime value",
                   expression: "now()",
@@ -409,19 +401,23 @@ defmodule Expression.Callbacks.Standard do
   end
 
   @doc """
-  Returns TRUE if any argument is TRUE
+  Returns TRUE if any argument is TRUE.
+  Returns the first truthy value found or otherwise false.
 
-  # Example
-
-      iex> Expression.evaluate!("@or(true, false)")
-      true
-      iex> Expression.evaluate!("@or(true, true)")
-      true
-      iex> Expression.evaluate!("@or(false, false)")
-      false
-      iex> Expression.evaluate!("@or(false, \\"foo\\")")
-      "foo"
+  Accepts any amount of arguments for testing truthiness.
   """
+  @expression_doc doc: "Return true if any of the values are true",
+                  expression: "or(true, false)",
+                  result: true
+  @expression_doc doc: "Return the first value that is truthy",
+                  expression: "or(false, \"foo\")",
+                  result: "foo"
+  @expression_doc expression: "or(true, true)",
+                  result: true
+  @expression_doc expression: "or(false, false)",
+                  result: false
+  @expression_doc expression: "or()",
+                  result: false
   def or_vargs(ctx, arguments) do
     arguments = eval_args!(arguments, ctx)
     Enum.reduce(arguments, fn a, b -> a || b end)

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -21,22 +21,15 @@ defmodule Expression.Callbacks.Standard do
   underscore.
   """
 
-  @doc """
-  Defines a new date value
-
-  # Example
-
-      iex> Expression.evaluate!("@date(2012, 12, 15)")
-      ~U[2012-12-15 00:00:00Z]
-
-  """
   import Expression.Callbacks.EvalHelpers
   use Expression.Autodoc
 
   @punctuation_pattern ~r/\s*[,:;!?.-]\s*|\s/
 
-  @expression_doc doc: "Construct a date from year, month, and day integers",
-                  expression: "date(year, month, day)",
+  @doc """
+  Construct a date from year, month, and day integers.
+  """
+  @expression_doc expression: "date(year, month, day)",
                   context: %{
                     "year" => 2022,
                     "month" => 1,

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -105,8 +105,6 @@ defmodule Expression.Callbacks.Standard do
       iex> Expression.evaluate!("@datetime_add(date(2021, 03, 1), -1, \\"D\\")")
       ~U[2021-02-28 00:00:00Z]
 
-      expr> @datetime_add(date, 2020, 02, 29)
-
   """
   def datetime_add(ctx, datetime, offset, unit) do
     datetime = extract_dateish(eval!(datetime, ctx))

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -37,7 +37,11 @@ defmodule Expression.Callbacks.Standard do
 
   @expression_doc doc: "Construct a date from year, month, and day integers",
                   expression: "@date(year, month, day)",
-                  context: %{"year" => 2022, "month" => 1, "day" => 31},
+                  context: %{
+                    "year" => 2022,
+                    "month" => 1,
+                    "day" => 31
+                  },
                   result: "2022-01-31T00:00:00Z"
   def date(ctx, year, month, day) do
     [year, month, day] = eval_args!([year, month, day], ctx)

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -36,13 +36,13 @@ defmodule Expression.Callbacks.Standard do
   @punctuation_pattern ~r/\s*[,:;!?.-]\s*|\s/
 
   @expression_doc doc: "Construct a date from year, month, and day integers",
-                  expression: "@date(year, month, day)",
+                  expression: "date(year, month, day)",
                   context: %{
                     "year" => 2022,
                     "month" => 1,
                     "day" => 31
                   },
-                  result: "2022-01-31T00:00:00Z"
+                  result: ~U[2022-01-31 00:00:00Z]
   def date(ctx, year, month, day) do
     [year, month, day] = eval_args!([year, month, day], ctx)
 

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -232,7 +232,7 @@ defmodule Expression.Callbacks.Standard do
       iex> DateTime.to_unix(eval_now) - DateTime.to_unix(now) in [0, 1]
       true
   """
-  @expression_doc doc: "return the current datetime",
+  @expression_doc doc: "return the current timestamp as a DateTime value",
                   expression: "now()",
                   fake_result: DateTime.utc_now()
   @expression_doc doc: "return the current datetime and format it using `datevalue`",

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -27,9 +27,10 @@ defmodule Expression.Callbacks.Standard do
   @punctuation_pattern ~r/\s*[,:;!?.-]\s*|\s/
 
   @doc """
-  Construct a date from year, month, and day integers.
+  Defines a new date value
   """
-  @expression_doc expression: "date(year, month, day)",
+  @expression_doc doc: "Construct a date from year, month, and day integers",
+                  expression: "date(year, month, day)",
                   context: %{
                     "year" => 2022,
                     "month" => 1,

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -104,6 +104,14 @@ defmodule Expression.Callbacks.Standard do
       ~U[2021-02-28 00:00:00Z]
 
   """
+  @expression_doc doc: "Calculates a new datetime based on the offset and unit provided.",
+                  expression: "datetime_add(datetime, offset, unit)",
+                  context: %{
+                    "datetime" => ~U[2022-07-31 00:00:00Z],
+                    "offset" => "1",
+                    "unit" => "M"
+                  },
+                  result: ~U[2022-08-31 00:00:00Z]
   def datetime_add(ctx, datetime, offset, unit) do
     datetime = extract_dateish(eval!(datetime, ctx))
     [offset, unit] = eval_args!([offset, unit], ctx)

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -31,9 +31,14 @@ defmodule Expression.Callbacks.Standard do
 
   """
   import Expression.Callbacks.EvalHelpers
+  use Expression.Autodoc
 
   @punctuation_pattern ~r/\s*[,:;!?.-]\s*|\s/
 
+  @expression_doc doc: "Construct a date from year, month, and day integers",
+                  expression: "@date(year, month, day)",
+                  context: %{"year" => 2022, "month" => 1, "day" => 31},
+                  result: "2022-01-31T00:00:00Z"
   def date(ctx, year, month, day) do
     [year, month, day] = eval_args!([year, month, day], ctx)
 
@@ -99,6 +104,8 @@ defmodule Expression.Callbacks.Standard do
       ~U[2020-02-28 00:00:00Z]
       iex> Expression.evaluate!("@datetime_add(date(2021, 03, 1), -1, \\"D\\")")
       ~U[2021-02-28 00:00:00Z]
+
+      expr> @datetime_add(date, 2020, 02, 29)
 
   """
   def datetime_add(ctx, datetime, offset, unit) do

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -128,19 +128,15 @@ defmodule Expression.Callbacks.Standard do
 
   It will fallback to "%Y-%m-%d %H:%M:%S" if no formatting is supplied
 
-  # Example
-
-      iex> Expression.evaluate!("@datevalue(date(2020, 12, 20))")
-      "2020-12-20 00:00:00"
-      iex> Expression.evaluate!("@datevalue(date(2020, 12, 20), '%Y-%m-%d')")
-      "2020-12-20"
-
   """
-  @expression_doc doc: "Convert a date string to a formatted date string",
+  @expression_doc doc: "Convert a date from a piece of text to a formatted date string",
                   expression: "datevalue(\"2022-01-01\")",
                   result: %{"__value__" => "2022-01-01 00:00:00", "date" => ~D[2022-01-01]}
-  @expression_doc doc: "Convert a date string and read the date field",
+  @expression_doc doc: "Convert a date from a piece of text and read the date field",
                   expression: "datevalue(\"2022-01-01\").date",
+                  result: ~D[2022-01-01]
+  @expression_doc doc: "Convert a date value and read the date field",
+                  expression: "datevalue(date(2022, 1, 1)).date",
                   result: ~D[2022-01-01]
   def datevalue(ctx, date, format) do
     [date, format] = eval!([date, format], ctx)
@@ -159,14 +155,13 @@ defmodule Expression.Callbacks.Standard do
 
   @doc """
   Returns only the day of the month of a date (1 to 31)
-
-  # Example
-
-      iex> now = DateTime.utc_now()
-      iex> day = Expression.evaluate!("@day(now())")
-      iex> day == now.day
-      true
   """
+  @expression_doc doc: "Getting today's day of the month",
+                  expression: "day(date(2022, 9, 10))",
+                  result: 10
+  @expression_doc doc: "Getting today's day of the month",
+                  expression: "day(now())",
+                  result: DateTime.utc_now().day
   def day(ctx, date) do
     %{day: day} = eval!(date, ctx)
     day

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -169,30 +169,28 @@ defmodule Expression.Callbacks.Standard do
 
   @doc """
   Moves a date by the given number of months
-
-  # Example
-
-      iex> now = DateTime.utc_now()
-      iex> future = Timex.shift(now, months: 1)
-      iex> date = Expression.evaluate!("@edate(now(), 1)")
-      iex> future.month == date.month
-      true
   """
+  @expression_doc doc: "Move the date in a date object by 1 month",
+                  expression: "edate(right_now, 1)",
+                  context: %{right_now: DateTime.new!(Date.new!(2022, 1, 1), Time.new!(0, 0, 0))},
+                  result:
+                    Timex.shift(DateTime.new!(Date.new!(2022, 1, 1), Time.new!(0, 0, 0)),
+                      months: 1
+                    )
+  @expression_doc doc: "Move the date store in a piece of text by 1 month",
+                  expression: "edate(\"2022-10-10\", 1)",
+                  result: ~D[2022-11-10]
   def edate(ctx, date, months) do
     [date, months] = eval_args!([date, months], ctx)
-    date |> Timex.shift(months: months)
+    extract_dateish(date) |> Timex.shift(months: months)
   end
 
   @doc """
   Returns only the hour of a datetime (0 to 23)
-
-  # Example
-
-      iex> now = DateTime.utc_now()
-      iex> hour = Expression.evaluate!("@hour(now())")
-      iex> now.hour == hour
-      true
   """
+  @expression_doc doc: "Get the current hour",
+                  expression: "hour(now())",
+                  result: DateTime.utc_now().hour
   def hour(ctx, date) do
     %{hour: hour} = eval!(date, ctx)
     hour
@@ -200,14 +198,10 @@ defmodule Expression.Callbacks.Standard do
 
   @doc """
   Returns only the minute of a datetime (0 to 59)
-
-  # Example
-
-      iex> now = DateTime.utc_now()
-      iex> minute = Expression.evaluate!("@minute(now)", %{"now" => now})
-      iex> now.minute == minute
-      true
   """
+  @expression_doc doc: "Get the current minute",
+                  expression: "minute(now())",
+                  result: DateTime.utc_now().minute
   def minute(ctx, date) do
     %{minute: minute} = eval!(date, ctx)
     minute
@@ -215,14 +209,10 @@ defmodule Expression.Callbacks.Standard do
 
   @doc """
   Returns only the month of a date (1 to 12)
-
-  # Example
-
-      iex> now = DateTime.utc_now()
-      iex> month = Expression.evaluate!("@month(now)", %{"now" => now})
-      iex> now.month == month
-      true
   """
+  @expression_doc doc: "Get the current month",
+                  expression: "month(now())",
+                  result: DateTime.utc_now().month
   def month(ctx, date) do
     %{month: month} = eval!(date, ctx)
     month
@@ -242,6 +232,14 @@ defmodule Expression.Callbacks.Standard do
       iex> DateTime.to_unix(eval_now) - DateTime.to_unix(now) in [0, 1]
       true
   """
+  @expression_doc doc: "return the current datetime",
+                  expression: "now()",
+                  fake_result: DateTime.utc_now()
+  @expression_doc doc: "return the current datetime and format it using `datevalue`",
+                  expression: "datevalue(now(), \"%Y-%m-%d\")",
+                  result: %{
+                    "__value__" => DateTime.utc_now() |> Timex.format!("%Y-%m-%d", :strftime)
+                  }
   def now(_ctx) do
     DateTime.utc_now()
   end

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -6,7 +6,7 @@ defmodule Expression.Eval do
   At a high level, an AST consists of a Keyword list with two top-level
   keys, either `:text` or `:expression`.
 
-  `Expression.eval!/3` will return the output for each entry in the Keyword
+  `Expression.Eval.eval!/3` will return the output for each entry in the Keyword
   list. `:text` entries are returned as regular strings. `:expression` entries
   are returned as typed values.
 

--- a/test/expression/autodoc_test.exs
+++ b/test/expression/autodoc_test.exs
@@ -18,7 +18,7 @@ defmodule Expression.AutodocTest do
                doc: "Construct a date from year, month, and day integers",
                expression: "date(year, month, day)",
                context: %{"day" => 31, "month" => 1, "year" => 2022},
-               result: ~U[2022-01-31 00:00:00Z]
+               result: ~D[2022-01-31]
              }
            ]
   end

--- a/test/expression/autodoc_test.exs
+++ b/test/expression/autodoc_test.exs
@@ -16,9 +16,9 @@ defmodule Expression.AutodocTest do
     assert expression_docs == [
              %{
                doc: "Construct a date from year, month, and day integers",
-               expression: "@date(year, month, day)",
+               expression: "date(year, month, day)",
                context: %{"day" => 31, "month" => 1, "year" => 2022},
-               result: "2022-01-31T00:00:00Z"
+               result: ~U[2022-01-31 00:00:00Z]
              }
            ]
   end

--- a/test/expression/autodoc_test.exs
+++ b/test/expression/autodoc_test.exs
@@ -7,7 +7,7 @@ defmodule Expression.AutodocTest do
   end
 
   test "expression docs" do
-    assert [{"date", args, docstring, expression_docs}] = find_docs(Standard, "date")
+    assert [{"date", :direct, args, docstring, expression_docs}] = find_docs(Standard, "date")
 
     assert docstring =~ "Defines a new date value"
 
@@ -24,7 +24,8 @@ defmodule Expression.AutodocTest do
   end
 
   test "regular docstrings" do
-    assert [{"has_time", args, docstring, expression_docs}] = find_docs(Standard, "has_time")
+    assert [{"has_time", :direct, args, docstring, expression_docs}] =
+             find_docs(Standard, "has_time")
 
     assert docstring =~ "Tests whether `expression` contains a time."
 
@@ -33,8 +34,18 @@ defmodule Expression.AutodocTest do
     assert expression_docs == []
   end
 
+  test "vargs" do
+    assert [{"or", :vargs, args, docstring, expression_docs}] = find_docs(Standard, "or")
+
+    assert docstring =~ "Returns TRUE if any argument is TRUE"
+
+    assert ["arguments"] = args
+
+    assert expression_docs
+  end
+
   test "undocumented" do
-    assert [{"map", args, docstring, expression_docs}] = find_docs(Standard, "map")
+    assert [{"map", :direct, args, docstring, expression_docs}] = find_docs(Standard, "map")
 
     refute docstring
 

--- a/test/expression/autodoc_test.exs
+++ b/test/expression/autodoc_test.exs
@@ -3,7 +3,12 @@ defmodule Expression.AutodocTest do
   alias Expression.Callbacks.Standard
 
   test "docs_for" do
-    assert [{"date", args, expression_docs}] = Standard.expression_docs()
+    all_expression_docs = Standard.expression_docs()
+
+    assert [{"date", args, docstring, expression_docs}] =
+             Enum.filter(all_expression_docs, &(elem(&1, 0) == "date"))
+
+    assert docstring =~ "Defines a new date value"
 
     assert ["year", "month", "day"] = args
 

--- a/test/expression/autodoc_test.exs
+++ b/test/expression/autodoc_test.exs
@@ -2,11 +2,12 @@ defmodule Expression.AutodocTest do
   use ExUnit.Case, async: true
   alias Expression.Callbacks.Standard
 
-  test "docs_for" do
-    all_expression_docs = Standard.expression_docs()
+  defp find_docs(module, name) do
+    Enum.filter(module.expression_docs(), &(elem(&1, 0) == name))
+  end
 
-    assert [{"date", args, docstring, expression_docs}] =
-             Enum.filter(all_expression_docs, &(elem(&1, 0) == "date"))
+  test "expression docs" do
+    assert [{"date", args, docstring, expression_docs}] = find_docs(Standard, "date")
 
     assert docstring =~ "Defines a new date value"
 
@@ -20,5 +21,25 @@ defmodule Expression.AutodocTest do
                result: "2022-01-31T00:00:00Z"
              }
            ]
+  end
+
+  test "regular docstrings" do
+    assert [{"has_time", args, docstring, expression_docs}] = find_docs(Standard, "has_time")
+
+    assert docstring =~ "Tests whether `expression` contains a time."
+
+    assert ["expression"] = args
+
+    assert expression_docs == []
+  end
+
+  test "undocumented" do
+    assert [{"map", args, docstring, expression_docs}] = find_docs(Standard, "map")
+
+    refute docstring
+
+    assert ["enumerable", "mapper"] = args
+
+    assert expression_docs == []
   end
 end

--- a/test/expression/autodoc_test.exs
+++ b/test/expression/autodoc_test.exs
@@ -42,4 +42,8 @@ defmodule Expression.AutodocTest do
 
     assert expression_docs == []
   end
+
+  test "private functions excluded" do
+    assert [] = find_docs(Standard, "extract_dateish")
+  end
 end

--- a/test/expression/autodoc_test.exs
+++ b/test/expression/autodoc_test.exs
@@ -1,0 +1,19 @@
+defmodule Expression.AutodocTest do
+  use ExUnit.Case, async: true
+  alias Expression.Callbacks.Standard
+
+  test "docs_for" do
+    assert [{"date", args, expression_docs}] = Standard.expression_docs()
+
+    assert ["year", "month", "day"] = args
+
+    assert expression_docs == [
+             %{
+               doc: "Construct a date from year, month, and day integers",
+               expression: "@date(year, month, day)",
+               context: %{"day" => 31, "month" => 1, "year" => 2022},
+               result: "2022-01-31T00:00:00Z"
+             }
+           ]
+  end
+end

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -52,9 +52,9 @@ defmodule Expression.EvalTest do
       {:ok, ast, "", _, _, _} = Parser.parse("@map(1..3, &date(2022, 5, &1))")
 
       assert [
-               ~U[2022-05-01 00:00:00Z],
-               ~U[2022-05-02 00:00:00Z],
-               ~U[2022-05-03 00:00:00Z]
+               ~D[2022-05-01],
+               ~D[2022-05-02],
+               ~D[2022-05-03]
              ] == Eval.eval!(ast, %{})
     end
 

--- a/test/expression_custom_callbacks_test.exs
+++ b/test/expression_custom_callbacks_test.exs
@@ -3,6 +3,7 @@ defmodule ExpressionCustomCallbacksTest do
 
   defmodule CustomCallback do
     use Expression.Callbacks
+    use Expression.Autodoc
 
     def echo(ctx, value) do
       value = eval!(value, ctx)

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -31,7 +31,7 @@ defmodule ExpressionTest do
       assert "true" == Expression.evaluate_as_string!("@(tRuE)")
       assert "false" == Expression.evaluate_as_string!("@(FaLsE)")
       assert "1.23" == Expression.evaluate_as_string!("@(1.23)")
-      assert "2022-06-28T00:00:00Z" == Expression.evaluate_as_string!("@date(2022, 6, 28)")
+      assert "2022-06-28" == Expression.evaluate_as_string!("@date(2022, 6, 28)")
       assert "123" == Expression.evaluate_as_string!("@([1,2,3])")
     end
 


### PR DESCRIPTION
It's useful to be able to extract samples from the documentation in a structured format to:

1. Automatically generate tests for them
2. Make them available in a convenient format for use for tooling purposes

Adds the following to any existing doc string already added. Adds to as is if no docstring is present.

<img width="877" alt="Screenshot 2022-10-30 at 11 12 11" src="https://user-images.githubusercontent.com/1065/198873335-b7a0bdfb-0416-43cd-a76c-cd29856464eb.png">

Complex types (return values with attributes) are now also automatically documented:

<img width="941" alt="Screenshot 2022-10-31 at 15 47 42" src="https://user-images.githubusercontent.com/1065/199036512-14068e41-0903-4d7a-b795-5cedb1dfb841.png">

The expressions documented are tested as doctests.

Adds the `expression_docs` function which returns this:

```elixir
iex(2)> Expression.Callbacks.Standard.expression_docs
[
  {"date", ["year", "month", "day"],
   [
     %{
       context: %{"day" => 31, "month" => 1, "year" => 2022},
       doc: "Construct a date from year, month, and day integers",
       expression: "date(year, month, day)",
       result: "2022-01-31T00:00:00Z"
     }
   ]}
]
iex(3)> 
```

The format is:

```elixir
@expression_doc doc: "Construct a date from year, month, and day integers",
                expression: "date(year, month, day)",
                context: %{"year" => 2022, "month" => 1, "day" => 31},
                result: "2022-01-31T00:00:00Z"
```

Where: 
* `doc` is the explanatory text added to the doctest.
* `expression` is the expression we want to test
* `context` is the context the expression is tested against
* `result` is the result we're expecting to get and are asserting against
