### PR TITLE
allow nested expressions

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -119,7 +119,12 @@ defmodule Expression.Eval do
     end
   end
 
+  def eval!({:literal, literal}, context, mod) when is_binary(literal) do
+    Expression.evaluate_as_string!(literal, context, mod)
+  end
+
   def eval!({:literal, literal}, _context, _mod), do: literal
+
   def eval!({:text, text}, _context, _mod), do: text
 
   def eval!({operator, [a, b]}, ctx, mod) when operator in @kernel_operators do

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -10,7 +10,7 @@ defmodule Expression.EvalTest do
   test "substitutions in substitutions" do
     assert "Your application was successful" ==
              Expression.evaluate_as_string!(
-               "Your application @if(conditional, \"was @confirm\", \"was @deny\")",
+               ~s|Your application @if(conditional, "was @confirm", "was @deny")|,
                %{
                  "conditional" => true,
                  "confirm" => "successful",
@@ -20,7 +20,7 @@ defmodule Expression.EvalTest do
 
     assert "Your application was unsuccessful" ==
              Expression.evaluate_as_string!(
-               "Your application @if(conditional, \"was @confirm\", \"was @deny\")",
+               ~s|Your application @if(conditional, "was @confirm", "was @deny")|,
                %{
                  "conditional" => false,
                  "confirm" => "successful",

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -7,6 +7,28 @@ defmodule Expression.EvalTest do
     assert "bar" == Expression.evaluate_as_string!("@foo", %{"foo" => "bar"})
   end
 
+  test "substitutions in substitutions" do
+    assert "Your application was successful" ==
+             Expression.evaluate_as_string!(
+               "Your application @if(conditional, \"was @confirm\", \"was @deny\")",
+               %{
+                 "conditional" => true,
+                 "confirm" => "successful",
+                 "deny" => "unsuccessful"
+               }
+             )
+
+    assert "Your application was unsuccessful" ==
+             Expression.evaluate_as_string!(
+               "Your application @if(conditional, \"was @confirm\", \"was @deny\")",
+               %{
+                 "conditional" => false,
+                 "confirm" => "successful",
+                 "deny" => "unsuccessful"
+               }
+             )
+  end
+
   test "attributes on substitutions" do
     assert "baz" == Expression.evaluate_as_string!("@foo.bar", %{"foo" => %{"bar" => "baz"}})
   end


### PR DESCRIPTION
Allows for the following:

```elixir
assert "Your application was successful" ==
             Expression.evaluate_as_string!(
               "Your application @if(conditional, \"was @confirm\", \"was @deny\")",
               %{
                 "conditional" => true,
                 "confirm" => "successful",
                 "deny" => "unsuccessful"
               }
             )
```