### PR TITLE
fix comparisons against default values

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -122,17 +122,17 @@ defmodule Expression do
   def stringify(map) when is_map(map), do: "#{inspect(map)}"
   def stringify(other), do: to_string(other)
 
-  defp default_value(val, opts \\ [])
-  defp default_value(%{"__value__" => default_value}, _opts), do: default_value
+  def default_value(val, opts \\ [])
+  def default_value(%{"__value__" => default_value}, _opts), do: default_value
 
-  defp default_value({:not_found, attributes}, opts) do
+  def default_value({:not_found, attributes}, opts) do
     if(opts[:handle_not_found], do: "@#{Enum.join(attributes, ".")}", else: nil)
   end
 
-  defp default_value(items, opts) when is_list(items),
+  def default_value(items, opts) when is_list(items),
     do: Enum.map(items, &default_value(&1, opts))
 
-  defp default_value(value, _opts), do: value
+  def default_value(value, _opts), do: value
 
   def evaluate(expression, context \\ %{}, mod \\ Expression.Callbacks) do
     {:ok, evaluate!(expression, context, mod)}

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -87,14 +87,14 @@ defmodule Expression do
     expression
     |> parse!
     |> Eval.eval!(Context.new(context), mod)
-    |> default_value()
+    |> Eval.default_value()
   end
 
   def evaluate_as_string!(expression, context \\ %{}, mod \\ Expression.Callbacks) do
     expression
     |> parse!
     |> Eval.eval!(Context.new(context), mod)
-    |> default_value(handle_not_found: true)
+    |> Eval.default_value(handle_not_found: true)
     |> stringify()
   end
 
@@ -121,18 +121,6 @@ defmodule Expression do
   def stringify(%Decimal{} = decimal), do: Decimal.to_string(decimal, :normal)
   def stringify(map) when is_map(map), do: "#{inspect(map)}"
   def stringify(other), do: to_string(other)
-
-  def default_value(val, opts \\ [])
-  def default_value(%{"__value__" => default_value}, _opts), do: default_value
-
-  def default_value({:not_found, attributes}, opts) do
-    if(opts[:handle_not_found], do: "@#{Enum.join(attributes, ".")}", else: nil)
-  end
-
-  def default_value(items, opts) when is_list(items),
-    do: Enum.map(items, &default_value(&1, opts))
-
-  def default_value(value, _opts), do: value
 
   def evaluate(expression, context \\ %{}, mod \\ Expression.Callbacks) do
     {:ok, evaluate!(expression, context, mod)}

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -184,6 +184,9 @@ defmodule Expression.Eval do
     apply(Kernel, operator, args)
   end
 
+  @doc """
+  Return the default value for a potentially complex value.
+  """
   def default_value(val, opts \\ [])
   def default_value(%{"__value__" => default_value}, _opts), do: default_value
 
@@ -195,6 +198,7 @@ defmodule Expression.Eval do
     do: Enum.map(items, &default_value(&1, opts))
 
   def default_value(value, _opts), do: value
+
   def decimal_op(:+, a, b), do: Decimal.add(a, b)
   def decimal_op(:*, a, b), do: Decimal.mult(a, b)
   def decimal_op(:/, a, b), do: Decimal.div(a, b)

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -186,6 +186,10 @@ defmodule Expression.Eval do
 
   @doc """
   Return the default value for a potentially complex value.
+
+  Complex values can be Maps that have a `__value__` key, if that's
+  returned then we can to use the `__value__` value when eval'ing against
+  operators or functions.
   """
   def default_value(val, opts \\ [])
   def default_value(%{"__value__" => default_value}, _opts), do: default_value

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -85,6 +85,20 @@ defmodule ExpressionTest do
                })
     end
 
+    @tag :current
+    test "operators against default values" do
+      assert %{"__value__" => to_string(Date.utc_today()), "date" => Date.utc_today()} ==
+               Expression.evaluate_block!("datevalue(today(), '%Y-%m-%d')")
+
+      assert Expression.evaluate_block!("date == today()", %{
+               "date" => Date.utc_today()
+             })
+
+      assert Expression.evaluate_block!("date == datevalue(today(), '%Y-%m-%d')", %{
+               "date" => to_string(Date.utc_today())
+             })
+    end
+
     test "example logical comparison between integers" do
       assert {:ok, true} ==
                Expression.evaluate("@(contact.age > 18)", %{"contact" => %{"age" => 20}})

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -85,7 +85,6 @@ defmodule ExpressionTest do
                })
     end
 
-    @tag :current
     test "operators against default values" do
       assert %{"__value__" => to_string(Date.utc_today()), "date" => Date.utc_today()} ==
                Expression.evaluate_block!("datevalue(today(), '%Y-%m-%d')")


### PR DESCRIPTION
Complex values (values returning a Map with a `__value__` key) are failing when eval'd against simple operators like `==`