### PR TITLE
Autodoc should reference callback module

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,11 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
-          experimental-otp: true
       - name: Restore dependencies cache
         uses: actions/cache@v2
         id: mix-cache

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: [1.13]
-        otp: [24]
+        elixir: ["1.14.0"]
+        otp: ["25"]
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -103,7 +103,7 @@ defmodule Expression.Autodoc do
         "#{stringify(result)}"
         ```
 
-        #{generate_ex_doc(doctest_prompt, expression, context || %{}, result)}
+        #{generate_ex_doc(doctest_prompt, module, expression, context || %{}, result)}
 
         ---
 
@@ -131,17 +131,19 @@ defmodule Expression.Autodoc do
     ])
   end
 
-  def generate_ex_doc(prompt \\ "iex", expression, context, result) do
+  def generate_ex_doc(prompt \\ "iex", module, expression, context, result) do
     """
         #{prompt}> import ExUnit.Assertions
         #{prompt}> result = Expression.evaluate_block!(
         ...>   #{inspect(expression)},
-        ...>   #{inspect(context || %{})}
+        ...>   #{inspect(context || %{})},
+        ...>   #{module}
         ...> )
         #{generate_assert(prompt, result)}
         #{prompt}> Expression.evaluate_as_string!(
         ...>   #{inspect("@" <> expression)},
-        ...>   #{inspect(context || %{})}
+        ...>   #{inspect(context || %{})},
+        ...>   #{module}
         ...> )
         #{inspect(stringify(result))}
     """

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -137,13 +137,13 @@ defmodule Expression.Autodoc do
         #{prompt}> result = Expression.evaluate_block!(
         ...>   #{inspect(expression)},
         ...>   #{inspect(context || %{})},
-        ...>   #{module}
+        ...>   #{inspect(module)}
         ...> )
         #{generate_assert(prompt, result)}
         #{prompt}> Expression.evaluate_as_string!(
         ...>   #{inspect("@" <> expression)},
         ...>   #{inspect(context || %{})},
-        ...>   #{module}
+        ...>   #{inspect(module)}
         ...> )
         #{inspect(stringify(result))}
     """

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -22,6 +22,7 @@ defmodule Expression.Callbacks.Standard do
   """
 
   import Expression.Callbacks.EvalHelpers
+  use Expression.Callbacks
   use Expression.Autodoc
 
   @punctuation_pattern ~r/\s*[,:;!?.-]\s*|\s/


### PR DESCRIPTION
Otherwise autodoc stuff we write for other callback modules fail because it attempts to test callback expressions against the standard module