### PR TITLE
fix(expression): operators against numeric default values

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -192,6 +192,10 @@ defmodule Expression.Eval do
   operators or functions.
   """
   def default_value(val, opts \\ [])
+
+  def default_value(%{"__value__" => default_value}, _opts) when is_integer(default_value),
+    do: to_string(default_value)
+
   def default_value(%{"__value__" => default_value}, _opts), do: default_value
 
   def default_value({:not_found, attributes}, opts) do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -96,6 +96,10 @@ defmodule ExpressionTest do
       assert Expression.evaluate_block!("date == datevalue(today(), '%Y-%m-%d')", %{
                "date" => to_string(Date.utc_today())
              })
+
+      assert Expression.evaluate_block!("block.value = \"1\"", %{
+               "block" => %{"value" => %{"__value__" => "1", "label" => "1", "name" => "1"}}
+             })
     end
 
     test "example logical comparison between integers" do


### PR DESCRIPTION
Fix evaluating operators against numeric default values. This was created to fix this simple **Stacks** use case:

```elixir
interaction_timeout(20)

card Button1 do
  buttons([One]) do
    text("Hello this is my first text.")
  end
end

card One, "1" do
  text("One")
end
```

Currently, when we evaluate the expression below we get `false` because it ends up evaluating `"1" == 1` at the Elixir's kernel level.

```elixir
Expression.evaluate_block!("block.value = \"1\"", %{
  "block" => %{"value" => %{"__value__" => "1", "label" => "1", "name" => "1"}}
})
```