### PR TITLE
fix datetime & date comparisons

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.0-otp-24
-erlang 24.3.4
+elixir 1.14.0-otp-25
+erlang 25.0.4

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -168,6 +168,42 @@ defmodule Expression.Eval do
     decimal_op(operator, a, b)
   end
 
+  def op(:>, a, b) when is_struct(a, DateTime) and is_struct(b, DateTime),
+    do: DateTime.compare(a, b) == :gt
+
+  def op(:>=, a, b) when is_struct(a, DateTime) and is_struct(b, DateTime),
+    do: DateTime.compare(a, b) in [:gt, :eq]
+
+  def op(:<, a, b) when is_struct(a, DateTime) and is_struct(b, DateTime),
+    do: DateTime.compare(a, b) == :lt
+
+  def op(:<=, a, b) when is_struct(a, DateTime) and is_struct(b, DateTime),
+    do: DateTime.compare(a, b) in [:lt, :eq]
+
+  def op(:==, a, b) when is_struct(a, DateTime) and is_struct(b, DateTime),
+    do: DateTime.compare(a, b) == :eq
+
+  def op(:=, a, b) when is_struct(a, Date) and is_struct(b, Date),
+    do: Date.compare(a, b) == :eq
+
+  def op(:>, a, b) when is_struct(a, Date) and is_struct(b, Date),
+    do: Date.compare(a, b) == :gt
+
+  def op(:>=, a, b) when is_struct(a, Date) and is_struct(b, Date),
+    do: Date.compare(a, b) in [:gt, :eq]
+
+  def op(:<, a, b) when is_struct(a, Date) and is_struct(b, Date),
+    do: Date.compare(a, b) == :lt
+
+  def op(:<=, a, b) when is_struct(a, Date) and is_struct(b, Date),
+    do: Date.compare(a, b) in [:lt, :eq]
+
+  def op(:==, a, b) when is_struct(a, Date) and is_struct(b, Date),
+    do: Date.compare(a, b) == :eq
+
+  def op(:=, a, b) when is_struct(a, Date) and is_struct(b, Date),
+    do: Date.compare(a, b) == :eq
+
   # when acting on any other supported type but still expected to be numeric
   def op(operator, a, b) when operator in @numeric_kernel_operators do
     args =

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -85,6 +85,7 @@ defmodule ExpressionTest do
                })
     end
 
+    @tag :current
     test "operators against default values" do
       assert %{"__value__" => to_string(Date.utc_today()), "date" => Date.utc_today()} ==
                Expression.evaluate_block!("datevalue(today(), '%Y-%m-%d')")
@@ -96,6 +97,45 @@ defmodule ExpressionTest do
       assert Expression.evaluate_block!("date == datevalue(today(), '%Y-%m-%d')", %{
                "date" => to_string(Date.utc_today())
              })
+    end
+
+    @tag :current
+    test "operators against datetimes" do
+      ctx = %{
+        "contact" => %{
+          "reminder_timestamp" => "2023-01-12T14:49:18.957984Z"
+        }
+      }
+
+      assert false ==
+               Expression.evaluate_block!(
+                 "contact.reminder_timestamp < datetime_add(contact.reminder_timestamp, -1, \"M\")",
+                 ctx
+               )
+
+      assert false ==
+               Expression.evaluate_block!(
+                 "contact.reminder_timestamp <= datetime_add(contact.reminder_timestamp, -1, \"M\")",
+                 ctx
+               )
+
+      assert true ==
+               Expression.evaluate_block!(
+                 "contact.reminder_timestamp > datetime_add(contact.reminder_timestamp, -1, \"M\")",
+                 ctx
+               )
+
+      assert true ==
+               Expression.evaluate_block!(
+                 "contact.reminder_timestamp >= datetime_add(contact.reminder_timestamp, -1, \"M\")",
+                 ctx
+               )
+
+      assert true ==
+               Expression.evaluate_block!(
+                 "contact.reminder_timestamp == datetime_add(contact.reminder_timestamp, 0, \"M\")",
+                 ctx
+               )
     end
 
     test "example logical comparison between integers" do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -85,7 +85,6 @@ defmodule ExpressionTest do
                })
     end
 
-    @tag :current
     test "operators against default values" do
       assert %{"__value__" => to_string(Date.utc_today()), "date" => Date.utc_today()} ==
                Expression.evaluate_block!("datevalue(today(), '%Y-%m-%d')")
@@ -99,7 +98,6 @@ defmodule ExpressionTest do
              })
     end
 
-    @tag :current
     test "operators against datetimes" do
       ctx = %{
         "contact" => %{


### PR DESCRIPTION
comparing datetimes with `<`, `<=`, `>`, `>=` break and aren't using the relevant module comparison functions for `=` and `==`. This fixes that.