### PR TITLE
Allow underscores in integer literals

### DIFF
--- a/lib/literal_helpers.ex
+++ b/lib/literal_helpers.ex
@@ -4,7 +4,13 @@ defmodule Expression.LiteralHelpers do
 
   def int do
     optional(string("-"))
-    |> concat(integer(min: 1))
+    |> times(
+      choice([
+        integer(min: 1),
+        ignore(utf8_char([?_]))
+      ]),
+      min: 1
+    )
     |> reduce({Enum, :join, [""]})
     |> map({String, :to_integer, []})
   end

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -76,6 +76,8 @@ defmodule Expression.ParserTest do
     test "literals" do
       assert_ast([expression: [literal: 1]], "@(1)")
       assert_ast([expression: [literal: -1]], "@(-1)")
+      assert_ast([expression: [literal: 123_456]], "@(123_456)")
+      assert_ast([expression: [literal: -123_456]], "@(-123_456)")
       assert_ast([expression: [literal: true]], "@(tRuE)")
       assert_ast([expression: [literal: false]], "@(fAlSe)")
       assert_ast([expression: [literal: Decimal.new("1.23")]], "@(1.23)")


### PR DESCRIPTION
Aligning with Elixir conventions of allowing `123_456` as a more readable means of displaying an Integer