### PR TITLE
Do not crash when trying to parse something that's not a literal.

### DIFF
--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -70,6 +70,8 @@ defmodule Expression.Context do
       # when we're getting something entirely unexpected
       {:error, _reason, _, _, _, _} -> binary
     end
+  rescue
+    ArgumentError -> binary
   end
 
   defp evaluate!(value), do: value

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -87,6 +87,11 @@ defmodule Expression.ParserTest do
         [expression: [literal: ~U[2022-05-24 00:00:00.0Z]]],
         "@(2022-05-24T00:00:00)"
       )
+
+      assert_ast(
+        [expression: [literal: "_she_calls_me_princes___🤔"]],
+        "@(\"_she_calls_me_princes___🤔\")"
+      )
     end
 
     test "lists" do

--- a/test/expression_context_test.exs
+++ b/test/expression_context_test.exs
@@ -1,4 +1,18 @@
 defmodule ExpressionContextTest do
   use ExUnit.Case, async: true
   doctest Expression.Context
+
+  @tag :current
+  test "context with underscores" do
+    assert %{
+             "trouble" => "_she_calls_me_princes___🤔",
+             "integer" => 1,
+             "string_integer" => 1
+           } ==
+             Expression.Context.new(%{
+               "string_integer" => "1",
+               "integer" => 1,
+               "trouble" => "_she_calls_me_princes___🤔"
+             })
+  end
 end

--- a/test/expression_context_test.exs
+++ b/test/expression_context_test.exs
@@ -2,7 +2,6 @@ defmodule ExpressionContextTest do
   use ExUnit.Case, async: true
   doctest Expression.Context
 
-  @tag :current
   test "context with underscores" do
     assert %{
              "trouble" => "_she_calls_me_princes___🤔",


### PR DESCRIPTION
When we create the `Expression.Context.new()`, we parse all keys & values. This sometimes means we are given things that simply aren't valid expression blocks -- when that happens, just degrade gracefully and return whatever was given rather than crashing.