### PR TITLE
do not strip leading zeros in floats & decimals

### DIFF
--- a/lib/literal_helpers.ex
+++ b/lib/literal_helpers.ex
@@ -17,9 +17,9 @@ defmodule Expression.LiteralHelpers do
 
   def decimal do
     optional(string("-"))
-    |> concat(integer(min: 1))
+    |> concat(utf8_string([?0..?9], min: 1))
     |> concat(string("."))
-    |> concat(integer(min: 1))
+    |> concat(utf8_string([?0..?9], min: 1))
     |> reduce({Enum, :join, [""]})
     |> map({Decimal, :new, []})
   end

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -190,6 +190,8 @@ defmodule Expression.EvalTest do
     assert Decimal.new("1.14286") == Decimal.round(Eval.eval!(ast, %{}), 5)
     {:ok, ast, "", _, _, _} = Parser.parse("@(6.8 / 2.0 + 1.5)")
     assert Decimal.new("4.9") == Eval.eval!(ast, %{})
+    {:ok, ast, "", _, _, _} = Parser.parse("@(2.002 * 0.05)")
+    assert Decimal.new("0.10010") == Eval.eval!(ast, %{})
   end
 
   test "text" do

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -82,6 +82,7 @@ defmodule Expression.ParserTest do
       assert_ast([expression: [literal: false]], "@(fAlSe)")
       assert_ast([expression: [literal: Decimal.new("1.23")]], "@(1.23)")
       assert_ast([expression: [literal: Decimal.new("-1.23")]], "@(-1.23)")
+      assert_ast([expression: [literal: Decimal.new("-0.00002")]], "@(-0.00002)")
 
       assert_ast(
         [expression: [literal: ~U[2022-05-24 00:00:00.0Z]]],


### PR DESCRIPTION
We parse a decimal by parsing two ints separated by a full stop.
However reading `0000001` as an int results in `1`, should read it as a string first and then convert it, otherwise '0.0001` is read as `0.1`