### PR TITLE
Remove decimal dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ iex(4)> Expression.evaluate_as_string!("info@@support.com")
 Expression knows the following types:
 
 ```elixir
-iex> # Decimals
+iex> # Floats
 iex> Expression.evaluate("@(1.23)")
-{:ok, [#Decimal<1.23>]}
+{:ok, [1.23}
 iex> # Integers
 iex> Expression.evaluate("@(1)")
 {:ok, [1]}

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -43,7 +43,6 @@ defmodule Expression do
           | map
           | DateTime.t()
           | Date.t()
-          | Decimal.t()
 
   alias Expression.Context
   alias Expression.Eval
@@ -139,7 +138,6 @@ defmodule Expression do
   def stringify(binary) when is_binary(binary), do: binary
   def stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)
   def stringify(%Date{} = date), do: Date.to_iso8601(date)
-  def stringify(%Decimal{} = decimal), do: Decimal.to_string(decimal, :normal)
   def stringify(map) when is_map(map), do: "#{inspect(map)}"
   def stringify(other), do: to_string(other)
 

--- a/lib/expression/autodoc.ex
+++ b/lib/expression/autodoc.ex
@@ -166,7 +166,6 @@ defmodule Expression.Autodoc do
   def type_of(%Time{}), do: "Time"
   def type_of(%Date{}), do: "Date"
   def type_of(%DateTime{}), do: "DateTime"
-  def type_of(%Decimal{}), do: "Decimal"
   def type_of(boolean) when is_boolean(boolean), do: "Boolean"
   def type_of(nil) when is_nil(nil), do: "Null"
   def type_of(integer) when is_integer(integer), do: "Integer"

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -419,10 +419,10 @@ defmodule Expression.Callbacks.Standard do
   Returns the result of a number raised to a power - equivalent to the ^ operator
   """
   @expression_doc expression: "power(2, 3)",
-                  fake_result: Decimal.from_float(8.0)
+                  fake_result: 8.0
   def power(ctx, a, b) do
     [a, b] = eval_args!([a, b], ctx)
-    Decimal.from_float(:math.pow(a, b))
+    :math.pow(a, b)
   end
 
   @doc """
@@ -871,18 +871,12 @@ defmodule Expression.Callbacks.Standard do
       var when is_float(var) or is_integer(var) ->
         true
 
-      var when is_struct(var, Decimal) ->
-        true
-
       var when is_binary(var) ->
-        Decimal.new(var)
-        true
+        String.match?(var, ~r/^\d+?.?\d+$/)
 
       _var ->
         false
     end
-  rescue
-    Decimal.Error -> false
   end
 
   @doc """
@@ -1103,12 +1097,12 @@ defmodule Expression.Callbacks.Standard do
   defp extract_numberish(expression) do
     with [match] <-
            Regex.run(~r/([0-9]+\.?[0-9]+)/u, replace_arabic_numerals(expression), capture: :first),
-         {decimal, ""} <- Decimal.parse(match) do
-      decimal
+         float <- parse_float(match) do
+      float
     else
       # Regex can return nil
       nil -> nil
-      # Decimal parsing can return :error
+      # Float parsing can return :error
       :error -> nil
     end
   end
@@ -1135,15 +1129,12 @@ defmodule Expression.Callbacks.Standard do
     end)
   end
 
-  defp parse_decimal(decimal) when is_struct(decimal, Decimal), do: decimal
-  defp parse_decimal(float) when is_float(float), do: Decimal.from_float(float)
+  def parse_float(number) when is_number(number), do: number
 
-  defp parse_decimal(number) when is_number(number), do: Decimal.new(number)
-
-  defp parse_decimal(binary) when is_binary(binary) do
-    case Decimal.parse(binary) do
-      {decimal, ""} -> decimal
-      :error -> :error
+  def parse_float(binary) when is_binary(binary) do
+    case Float.parse(binary) do
+      {float, ""} -> float
+      _ -> nil
     end
   end
 
@@ -1173,13 +1164,13 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "has_number_eq(\"the number is 40\", \"42\")", result: false
   @expression_doc expression: "has_number_eq(\"the number is 40\", \"foo\")", result: false
   @expression_doc expression: "has_number_eq(\"four hundred\", \"foo\")", result: false
-  def has_number_eq(ctx, expression, decimal) do
-    [expression, decimal] = eval_args!([expression, decimal], ctx)
+  def has_number_eq(ctx, expression, float) do
+    [expression, float] = eval_args!([expression, float], ctx)
 
-    with %Decimal{} = number <- extract_numberish(expression),
-         %Decimal{} = decimal <- parse_decimal(decimal) do
+    with number when is_number(number) <- extract_numberish(expression),
+         float when is_number(float) <- parse_float(float) do
       # Future match result: number
-      Decimal.eq?(number, decimal)
+      float == number
     else
       nil -> false
       :error -> false
@@ -1196,13 +1187,13 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "has_number_gt(\"the number is 40\", \"40\")", result: false
   @expression_doc expression: "has_number_gt(\"the number is 40\", \"foo\")", result: false
   @expression_doc expression: "has_number_gt(\"four hundred\", \"foo\")", result: false
-  def has_number_gt(ctx, expression, decimal) do
-    [expression, decimal] = eval_args!([expression, decimal], ctx)
+  def has_number_gt(ctx, expression, float) do
+    [expression, float] = eval_args!([expression, float], ctx)
 
-    with %Decimal{} = number <- extract_numberish(expression),
-         %Decimal{} = decimal <- parse_decimal(decimal) do
+    with number when is_number(number) <- extract_numberish(expression),
+         float when is_number(float) <- parse_float(float) do
       # Future match result: number
-      Decimal.gt?(number, decimal)
+      number > float
     else
       nil -> false
       :error -> false
@@ -1219,13 +1210,13 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "has_number_gte(\"the number is 40\", \"45\")", result: false
   @expression_doc expression: "has_number_gte(\"the number is 40\", \"foo\")", result: false
   @expression_doc expression: "has_number_gte(\"four hundred\", \"foo\")", result: false
-  def has_number_gte(ctx, expression, decimal) do
-    [expression, decimal] = eval_args!([expression, decimal], ctx)
+  def has_number_gte(ctx, expression, float) do
+    [expression, float] = eval_args!([expression, float], ctx)
 
-    with %Decimal{} = number <- extract_numberish(expression),
-         %Decimal{} = decimal <- parse_decimal(decimal) do
+    with number when is_number(number) <- extract_numberish(expression),
+         float when is_number(float) <- parse_float(float) do
       # Future match result: number
-      Decimal.gt?(number, decimal) || Decimal.eq?(number, decimal)
+      number >= float
     else
       nil -> false
       :error -> false
@@ -1242,13 +1233,13 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "has_number_lt(\"the number is 40\", \"40\")", result: false
   @expression_doc expression: "has_number_lt(\"the number is 40\", \"foo\")", result: false
   @expression_doc expression: "has_number_lt(\"four hundred\", \"foo\")", result: false
-  def has_number_lt(ctx, expression, decimal) do
-    [expression, decimal] = eval_args!([expression, decimal], ctx)
+  def has_number_lt(ctx, expression, float) do
+    [expression, float] = eval_args!([expression, float], ctx)
 
-    with %Decimal{} = number <- extract_numberish(expression),
-         %Decimal{} = decimal <- parse_decimal(decimal) do
+    with number when is_number(number) <- extract_numberish(expression),
+         float when is_number(float) <- parse_float(float) do
       # Future match result: number
-      Decimal.lt?(number, decimal)
+      number < float
     else
       nil -> false
       :error -> false
@@ -1264,13 +1255,13 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "has_number_lte(\"the number is 42.0\", \"40\")", result: false
   @expression_doc expression: "has_number_lte(\"the number is 40\", \"foo\")", result: false
   @expression_doc expression: "has_number_lte(\"four hundred\", \"foo\")", result: false
-  def has_number_lte(ctx, expression, decimal) do
-    [expression, decimal] = eval_args!([expression, decimal], ctx)
+  def has_number_lte(ctx, expression, float) do
+    [expression, float] = eval_args!([expression, float], ctx)
 
-    with %Decimal{} = number <- extract_numberish(expression),
-         %Decimal{} = decimal <- parse_decimal(decimal) do
+    with number when is_number(number) <- extract_numberish(expression),
+         float when is_number(float) <- parse_float(float) do
       # Future match result: number
-      Decimal.lt?(number, decimal) || Decimal.eq?(number, decimal)
+      number <= float
     else
       nil -> false
       :error -> false

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -662,18 +662,12 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "percent(2/10)", result: "20%"
   @expression_doc expression: "percent(0.2)", result: "20%"
   @expression_doc expression: "percent(d)", context: %{"d" => "0.2"}, result: "20%"
-  def percent(ctx, decimal) do
-    decimal =
-      case eval!(decimal, ctx) do
-        float when is_float(float) -> Decimal.from_float(float)
-        binary when is_binary(binary) -> Decimal.new(binary)
-        decimal when is_struct(decimal, Decimal) -> decimal
-      end
+  def percent(ctx, float) do
+    float = eval!(float, ctx)
 
-    decimal
-    |> Decimal.mult(100)
-    |> Decimal.to_float()
-    |> Number.Percentage.number_to_percentage(precision: 0)
+    with float when is_number(float) <- parse_float(float) do
+      Number.Percentage.number_to_percentage(float * 100, precision: 0)
+    end
   end
 
   @doc """

--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -23,9 +23,9 @@ defmodule Expression.Context do
     iex> Expression.Context.new(%{float: 1.234})
     %{"float" => 1.234}
     iex> now = DateTime.utc_now()
-    iex> ctx = Expression.Context.new(%{decimal: "1.234", nested: %{date: now}})
-    iex> ctx["decimal"]
-    #Decimal<1.234>
+    iex> ctx = Expression.Context.new(%{float: "1.234", nested: %{date: now}})
+    iex> ctx["float"]
+    1.234
     iex> now == ctx["nested"]["date"]
     true
     iex> Expression.Context.new(%{mixed: ["2020-12-13T23:34:45", 1, "true", "binary"]})

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -158,16 +158,6 @@ defmodule Expression.Eval do
     apply(Kernel, operator, [a, b])
   end
 
-  # when acting on Decimal types
-  def op(operator, a, b)
-      when operator in @kernel_operators and
-             is_struct(a, Decimal) and
-             is_struct(b, Decimal) do
-    [a, b] = Enum.map([a, b], &guard_type!(&1, :num))
-
-    decimal_op(operator, a, b)
-  end
-
   def op(:>, a, b) when is_struct(a, DateTime) and is_struct(b, DateTime),
     do: DateTime.compare(a, b) == :gt
 
@@ -239,24 +229,10 @@ defmodule Expression.Eval do
 
   def default_value(value, _opts), do: value
 
-  def decimal_op(:+, a, b), do: Decimal.add(a, b)
-  def decimal_op(:*, a, b), do: Decimal.mult(a, b)
-  def decimal_op(:/, a, b), do: Decimal.div(a, b)
-  def decimal_op(:-, a, b), do: Decimal.sub(a, b)
-  def decimal_op(:>, a, b), do: Decimal.gt?(a, b)
-  def decimal_op(:>=, a, b), do: Decimal.compare(a, b) in [:gt, :eq]
-  def decimal_op(:<, a, b), do: Decimal.lt?(a, b)
-  def decimal_op(:<=, a, b), do: Decimal.compare(a, b) in [:lt, :eq]
-  def decimal_op(:==, a, b), do: Decimal.eq?(a, b)
-  def decimal_op(:!=, a, b), do: not Decimal.eq?(a, b)
-
-  def decimal_op(operator, _a, _b),
-    do: raise("Invalid operator #{inspect(operator)} for decimal values.")
-
   def not_founds_as_nil({:not_found, _}), do: nil
   def not_founds_as_nil(other), do: other
 
-  defp guard_type!(v, :num) when is_number(v) or is_struct(v, Decimal), do: v
+  defp guard_type!(v, :num) when is_number(v), do: v
 
   defp guard_type!({:not_found, attributes}, :num),
     do: raise("attribute is not found: `#{Enum.join(attributes, ".")}`")

--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -26,7 +26,7 @@ defmodule Expression.Parser do
       datetime(),
       date(),
       time(),
-      decimal(),
+      float(),
       int(),
       boolean(),
       single_quoted_string(),

--- a/lib/literal_helpers.ex
+++ b/lib/literal_helpers.ex
@@ -15,17 +15,17 @@ defmodule Expression.LiteralHelpers do
     |> map({String, :to_integer, []})
   end
 
-  def decimal do
+  def float do
     optional(string("-"))
     |> concat(utf8_string([?0..?9], min: 1))
     |> concat(string("."))
     |> concat(utf8_string([?0..?9], min: 1))
     |> reduce({Enum, :join, [""]})
-    |> map({Decimal, :new, []})
+    |> map({String, :to_float, []})
   end
 
   def numeric do
-    choice([int(), decimal()])
+    choice([int(), float()])
   end
 
   def single_quoted_string do

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,6 @@ defmodule Expression.MixProject do
   defp deps do
     [
       {:credo, "~> 1.5", only: [:dev], runtime: false},
-      {:decimal, "~> 2.0"},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.28.2", only: :dev, runtime: false},
       {:ex_phone_number, "~> 0.3.0"},

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -181,17 +181,17 @@ defmodule Expression.EvalTest do
 
   test "arithmetic with decimals" do
     {:ok, ast, "", _, _, _} = Parser.parse("@(1.5 + 1.5)")
-    assert Decimal.new("3.0") == Eval.eval!(ast, %{})
+    assert 3.0 == Eval.eval!(ast, %{})
     {:ok, ast, "", _, _, _} = Parser.parse("@(1.5 + 2.5 * 3.5)")
-    assert Decimal.new("10.25") == Eval.eval!(ast, %{})
+    assert 10.25 == Eval.eval!(ast, %{})
     {:ok, ast, "", _, _, _} = Parser.parse("@((1.5 + 2.5) * 3.5)")
-    assert Decimal.new("14.00") == Eval.eval!(ast, %{})
+    assert 14.00 == Eval.eval!(ast, %{})
     {:ok, ast, "", _, _, _} = Parser.parse("@((1.5 + 2.5) / 3.5)")
-    assert Decimal.new("1.14286") == Decimal.round(Eval.eval!(ast, %{}), 5)
+    assert 1.1428571428571428 == Eval.eval!(ast, %{})
     {:ok, ast, "", _, _, _} = Parser.parse("@(6.8 / 2.0 + 1.5)")
-    assert Decimal.new("4.9") == Eval.eval!(ast, %{})
+    assert 4.9 == Eval.eval!(ast, %{})
     {:ok, ast, "", _, _, _} = Parser.parse("@(2.002 * 0.05)")
-    assert Decimal.new("0.10010") == Eval.eval!(ast, %{})
+    assert 0.10010 == Eval.eval!(ast, %{})
   end
 
   test "text" do

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -192,6 +192,16 @@ defmodule Expression.EvalTest do
     assert 4.9 == Eval.eval!(ast, %{})
     {:ok, ast, "", _, _, _} = Parser.parse("@(2.002 * 0.05)")
     assert 0.10010 == Eval.eval!(ast, %{})
+    {:ok, ast, "", _, _, _} = Parser.parse("@(2 > 0.5)")
+    assert true == Eval.eval!(ast, %{})
+    {:ok, ast, "", _, _, _} = Parser.parse("@(2 >= 2.0)")
+    assert true == Eval.eval!(ast, %{})
+    {:ok, ast, "", _, _, _} = Parser.parse("@(2 < 0.5)")
+    assert false == Eval.eval!(ast, %{})
+    {:ok, ast, "", _, _, _} = Parser.parse("@(2 <= 2.0)")
+    assert true == Eval.eval!(ast, %{})
+    {:ok, ast, "", _, _, _} = Parser.parse("@(2 == 2.0)")
+    assert true == Eval.eval!(ast, %{})
   end
 
   test "text" do

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -80,9 +80,9 @@ defmodule Expression.ParserTest do
       assert_ast([expression: [literal: -123_456]], "@(-123_456)")
       assert_ast([expression: [literal: true]], "@(tRuE)")
       assert_ast([expression: [literal: false]], "@(fAlSe)")
-      assert_ast([expression: [literal: Decimal.new("1.23")]], "@(1.23)")
-      assert_ast([expression: [literal: Decimal.new("-1.23")]], "@(-1.23)")
-      assert_ast([expression: [literal: Decimal.new("-0.00002")]], "@(-0.00002)")
+      assert_ast([expression: [literal: 1.23]], "@(1.23)")
+      assert_ast([expression: [literal: -1.23]], "@(-1.23)")
+      assert_ast([expression: [literal: -0.00002]], "@(-0.00002)")
 
       assert_ast(
         [expression: [literal: ~U[2022-05-24 00:00:00.0Z]]],
@@ -453,7 +453,7 @@ defmodule Expression.ParserTest do
 
   describe "types" do
     test "decimal" do
-      assert_ast([expression: [literal: Decimal.new("1.23")]], "@(1.23)")
+      assert_ast([expression: [literal: 1.23]], "@(1.23)")
     end
 
     test "datetime" do


### PR DESCRIPTION
This comes out of #100 , it turns out we can do without the Decimal package and having it adds all sorts of added complexity when we need to do basic arithmatic like > or >= etc. Using floats has Elixir handle that for us directly instead.