### PR TITLE
fix handling of default values in builtins and callbacks

### DIFF
--- a/lib/expression/v2/compile.ex
+++ b/lib/expression/v2/compile.ex
@@ -39,7 +39,7 @@ defmodule Expression.V2.Compile do
   is also pure and is suitable for caching.
   """
   @spec compile([any]) ::
-          (Expression.V2.Context.t() -> [any])
+          (Expression.V2.Context.t() -> any)
   def compile(ast) do
     # convert to valid Elixir AST
     quoted = wrap_in_context(to_quoted(ast))

--- a/test/expression/v2/eval_test.exs
+++ b/test/expression/v2/eval_test.exs
@@ -52,6 +52,19 @@ defmodule Expression.V2.EvalTest do
       assert 5 == eval("1 * 5")
     end
 
+    test "arithmetic against default values" do
+      assert 50 ==
+               eval(
+                 "5 * foo",
+                 %{
+                   "foo" => %{
+                     "__value__" => 10,
+                     "other_attributes" => "ignored"
+                   }
+                 }
+               )
+    end
+
     test "precedence" do
       assert 12 == eval("2 * 5 + 2")
     end
@@ -62,6 +75,10 @@ defmodule Expression.V2.EvalTest do
 
     test "functions with vars" do
       assert 50 == eval("day(date(2023, 2, 10)) * 5")
+    end
+
+    test "functions with default values" do
+      assert 50 = eval("day(foo) * 5", %{"foo" => %{"__value__" => Date.new!(2023, 2, 10)}})
     end
 
     test "ints & floats" do


### PR DESCRIPTION
When we evaluate things in a function or using built ins we should use the __value__ of any complex values used.
Otherwise we end up in a situation where `foo * 5` could be evaluated as `%{"__value__" => 10} * 5` which would fail when instead we just want to do `10 * 5`.