### PR TITLE
fix parser mistakingly seeing *bold* as multiplication in shorthands

### DIFF
--- a/lib/expression/v2/parser.ex
+++ b/lib/expression/v2/parser.ex
@@ -379,7 +379,7 @@ defmodule Expression.V2.Parser do
   # Parsed a short hand such as `@now()`
   expression_shorthand =
     ignore(string("@"))
-    |> concat(wrap(parsec(:term_operator)))
+    |> concat(wrap(reduce(compound_term_with_property_or_attribute, :fold_infixl)))
 
   single_at = string("@")
 

--- a/test/expression/v2/parser_test.exs
+++ b/test/expression/v2/parser_test.exs
@@ -209,4 +209,16 @@ defmodule Expression.V2.ParserTest do
                Parser.expression("?")
     end
   end
+
+  describe "failing examples" do
+    test "*BOLD*" do
+      assert {:ok,
+              [
+                "\nHi there ",
+                [{"__property__", ["contact", "whatsapp_profile_name"]}],
+                "\n\n*HANGMAN*)\n)\n"
+              ], "", _, _,
+              _} = Parser.parse("\nHi there @contact.whatsapp_profile_name\n\n*HANGMAN*)\n)\n")
+    end
+  end
 end


### PR DESCRIPTION
This `"\nHi there @contact.whatsapp_profile_name\n\n*HANGMAN*)\n)\n"` wasn't parsed correctly