### PR TITLE
Truncate datetime microseconds to precision 6

### DIFF
--- a/lib/date_helpers.ex
+++ b/lib/date_helpers.ex
@@ -109,13 +109,17 @@ defmodule Expression.DateHelpers do
 
           {microseconds, values} = Keyword.pop(values, :microsecond, 0)
 
-          microsecond_entry =
-            {microseconds,
-             microseconds
-             |> to_string()
-             |> String.length()}
+          # Elixir's DateTime only supports microseconds up to precision 6
+          microseconds_string = to_string(microseconds)
 
-          Keyword.put(values, :microsecond, microsecond_entry)
+          microseconds_precision = min(String.length(microseconds_string), 6)
+
+          microseconds =
+            microseconds_string
+            |> String.slice(0, microseconds_precision)
+            |> String.to_integer()
+
+          Keyword.put(values, :microsecond, {microseconds, microseconds_precision})
 
         [us_format: parsed_value] ->
           [:day, :month, :year, :hour, :minute, :second]

--- a/test/expression/context_test.exs
+++ b/test/expression/context_test.exs
@@ -1,0 +1,19 @@
+defmodule Expression.ContextTest do
+  use ExUnit.Case
+  alias Expression.Context
+
+  test "new context from a context containing a datetime string" do
+    context = %{"block" => %{"value" => %{"program_start_date" => "2022-11-10T13:40:05.921378"}}}
+
+    assert %{"block" => %{"value" => %{"program_start_date" => ~U[2022-11-10 13:40:05.921378Z]}}} =
+             Context.new(context)
+  end
+
+  test "new context from a context containing a datetime string with microseconds precision 7" do
+    context = %{"block" => %{"value" => %{"program_start_date" => "2022-11-10T13:40:05.9213782"}}}
+
+    # Assert that the microseconds are truncated to precision 6 (the maximum precision supported by Elixir's DateTime)
+    assert %{"block" => %{"value" => %{"program_start_date" => ~U[2022-11-10 13:40:05.921378Z]}}} =
+             Context.new(context)
+  end
+end


### PR DESCRIPTION
It seems like Elixir's `DateTime` only supports microseconds up to precision 6, which causes our parser to throw exceptions for datetime strings containing microseconds with precision greater than 6.

See for example this code from Elixir's source code: https://github.com/elixir-lang/elixir/blob/6f96693b355a9b670f2630fd8e6217b69e325c5a/lib/elixir/lib/calendar/iso.ex#L242

Also notice DateTime truncating microseconds to precision 6 when parsing an ISO8601 string with precision 7 (notice the "2" getting dropped):
```
iex(2)> DateTime.from_iso8601("2022-11-10T13:40:05.9213782Z")
{:ok, ~U[2022-11-10 13:40:05.921378Z], 0}
```

This PR updates `DateHelpers.to_datetime/1` so that it drops microseconds greater than precision 6.
