### PR TITLE
Give datetime comparisons some more breathing room on slower CIs and use literals with builtin functions

### DIFF
--- a/lib/expression/v2.ex
+++ b/lib/expression/v2.ex
@@ -112,7 +112,14 @@ defmodule Expression.V2 do
   """
   @spec eval_block(String.t(), context :: Context.t()) ::
           term | {:error, reason :: String.t(), bad_parts :: String.t()}
-  def eval_block(expression_block, context \\ Context.new()) do
+  def eval_block(expression_block, context \\ Context.new())
+
+  def eval_block(expression_block, map_context)
+      when is_map(map_context) and not is_struct(map_context, Context) do
+    eval_block(expression_block, Context.new(map_context))
+  end
+
+  def eval_block(expression_block, context) do
     with {:ok, ast} <- parse_block(expression_block) do
       hd(eval_block_ast(ast, context))
     end
@@ -123,6 +130,11 @@ defmodule Expression.V2 do
   """
   @spec eval(expression :: String.t(), context :: Context.t()) :: [term]
   def eval(expression, context \\ Context.new())
+
+  def eval(expression, map_context)
+      when is_map(map_context) and not is_struct(map_context, Context) do
+    eval(expression, Context.new(map_context))
+  end
 
   def eval(expression, context) when is_binary(expression) do
     with {:ok, parsed_parts} <- parse(expression) do

--- a/lib/expression/v2/compile.ex
+++ b/lib/expression/v2/compile.ex
@@ -166,9 +166,16 @@ defmodule Expression.V2.Compile do
               function_name in @built_ins and
               is_list(arguments) do
     default_values =
-      Enum.map(arguments, fn argument ->
-        {{:., [], [{:__aliases__, [alias: false], [:Expression, :V2]}, :default_value]}, [],
-         [quoted(argument), {:context, [], nil}]}
+      Enum.map(arguments, fn
+        argument when is_integer(argument) ->
+          quoted(argument)
+
+        "\"" <> _string = argument ->
+          quoted(argument)
+
+        argument ->
+          {{:., [], [{:__aliases__, [alias: false], [:Expression, :V2]}, :default_value]}, [],
+           [quoted(argument), {:context, [], nil}]}
       end)
 
     {String.to_existing_atom(function_name), [], default_values}

--- a/test/expression/v2/eval_test.exs
+++ b/test/expression/v2/eval_test.exs
@@ -26,6 +26,19 @@ defmodule Expression.V2.EvalTest do
     end
   end
 
+  describe "map as context" do
+    test "eval_block accepts a map" do
+      assert V2.eval_block("contact.name", %{"contact" => %{"name" => "Mary"}}) == "Mary"
+    end
+
+    test "eval accepts a map" do
+      assert V2.eval("hello @contact.name", %{"contact" => %{"name" => "Mary"}}) == [
+               "hello ",
+               "Mary"
+             ]
+    end
+  end
+
   describe "eval_as_string" do
     test "with missing vars" do
       assert "hello @one.two.three" == Expression.V2.eval_as_string("hello @one.two.three")

--- a/test/expression/v2_test.exs
+++ b/test/expression/v2_test.exs
@@ -17,5 +17,22 @@ defmodule Expression.V2Test do
              fn _context -> ["one", "two"] end
              """) == V2.debug(~S|["one", "two"]|)
     end
+
+    test "default values not used for integers and builtins" do
+      assert "fn _context -> 1 + 1 end" == V2.debug("1 + 1")
+    end
+
+    test "default values not used for strings and builtins" do
+      assert "fn _context -> \"hello\" > \"bye\" end" == V2.debug("\"hello\" > \"bye\"")
+    end
+
+    test "default values used for variables and builtins" do
+      assert String.trim("""
+             fn context ->
+               Expression.V2.default_value(context.vars["a"], context) *
+                 Expression.V2.default_value(context.vars["b"], context)
+             end
+             """) == V2.debug("a * b")
+    end
   end
 end

--- a/test/expression/v2_test.exs
+++ b/test/expression/v2_test.exs
@@ -23,7 +23,7 @@ defmodule Expression.V2Test do
     end
 
     test "default values not used for strings and builtins" do
-      assert "fn _context -> \"hello\" > \"bye\" end" == V2.debug("\"hello\" > \"bye\"")
+      assert "fn _context -> \"hello\" == \"bye\" end" == V2.debug("\"hello\" == \"bye\"")
     end
 
     test "default values used for variables and builtins" do

--- a/test/expression/v2_test.exs
+++ b/test/expression/v2_test.exs
@@ -25,7 +25,8 @@ defmodule Expression.V2Test do
     test "default values not used for strings and builtins" do
       assert String.trim("""
              fn _context -> "hello" == "bye" end
-             """) == V2.debug("\"hello\" == \"bye\"")
+             """) ==
+               V2.debug(~S|"hello" == "bye"|)
     end
 
     test "default values used for variables and builtins" do

--- a/test/expression/v2_test.exs
+++ b/test/expression/v2_test.exs
@@ -23,7 +23,9 @@ defmodule Expression.V2Test do
     end
 
     test "default values not used for strings and builtins" do
-      assert "fn _context -> \"hello\" == \"bye\" end" == V2.debug("\"hello\" == \"bye\"")
+      assert String.trim("""
+             fn _context -> "hello" == "bye" end
+             """) == V2.debug("\"hello\" == \"bye\"")
     end
 
     test "default values used for variables and builtins" do


### PR DESCRIPTION
1. The Compat module is useful but also too strict on slower machines/CI because it'll fail on microsecond differences for 
expressions involving dynamically generated timestamps. 
2. When we're doing `1 * 1` and both sides of the operator are integers or strings, there's no need to call `default_value()` on them as that won't have any effect. Side step that function call as an optimisation, mostly to generate more readable debug output and save the CPU some function invocation work during eval.