### PR TITLE
do not attempt to treat a Date struct as a map

### DIFF
--- a/lib/expression/v2/compat.ex
+++ b/lib/expression/v2/compat.ex
@@ -221,7 +221,7 @@ defmodule Expression.V2.Compat do
   def normalize_value(%DateTime{} = datetime), do: DateTime.truncate(datetime, :second)
   def normalize_value(list) when is_list(list), do: Enum.map(list, &normalize_value/1)
 
-  def normalize_value(map) when is_map(map) do
+  def normalize_value(map) when is_map(map) and not is_struct(map) do
     map
     |> Enum.map(fn {key, value} -> {key, normalize_value(value)} end)
     |> Enum.into(%{})


### PR DESCRIPTION
`%Date{}` structs should be returned as is when normalised, except they're being treated as a map because a struct is a map underneath, however that breaks and isn't what we want to happen. 