### PR TITLE
[sc-20833] fix(callbacks): support for numbers in has_all_words/2

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -905,7 +905,7 @@ defmodule Expression.Callbacks.Standard do
 
     results =
       patterns
-      |> Enum.map(&Regex.run(&1, haystack))
+      |> Enum.map(&Regex.run(&1, to_string(haystack)))
       |> Enum.map(fn
         [match] -> match
         nil -> nil

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -64,22 +64,11 @@ defmodule Expression.Eval do
   end
 
   def eval!({:function, opts}, context, mod) do
-    name = opts[:name] || raise "Functions need a name"
+    function_name = opts[:name] || raise "Functions need a name"
     args = opts[:args] || []
+    arguments = Enum.reduce_while(args, [], &args_reducer(&1, function_name, context, mod, &2))
 
-    arguments =
-      Enum.reduce_while(args, [], fn {type, _args} = function, acc ->
-        if type in @allowed_nested_function_arguments do
-          value = eval!(function, context, mod)
-          flag = if value == true && name == "or", do: :halt, else: :cont
-
-          {flag, acc ++ [[literal: value]]}
-        else
-          {:cont, acc ++ [function]}
-        end
-      end)
-
-    case mod.handle(name, arguments, context) do
+    case mod.handle(function_name, arguments, context) do
       {:ok, value} -> value
       {:error, reason} -> "ERROR: #{inspect(reason)}"
     end
@@ -246,4 +235,15 @@ defmodule Expression.Eval do
 
   def handle_not_found({:not_found, _}), do: nil
   def handle_not_found(value), do: value
+
+  defp args_reducer({type, _args} = function, function_name, context, mod, acc)
+       when type in @allowed_nested_function_arguments do
+    value = eval!(function, context, mod)
+    flag = if value == true && function_name == "or", do: :halt, else: :cont
+
+    {flag, acc ++ [[literal: value]]}
+  end
+
+  defp args_reducer(function, _function_name, _context, _mod, acc),
+    do: {:cont, acc ++ [function]}
 end

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -45,6 +45,14 @@ defmodule Expression.EvalTest do
                  "deny" => "unsuccessful"
                }
              )
+
+    assert "true" ==
+             Expression.evaluate_as_string!(
+               ~s|@or(answer == 1, has_all_words(answer, "red fox"))|,
+               %{
+                 "answer" => "1"
+               }
+             )
   end
 
   test "attributes on substitutions" do
@@ -68,6 +76,10 @@ defmodule Expression.EvalTest do
     {:ok, ast, "", _, _, _} = Parser.parse(~s[@has_any_word("The Quick Brown Fox", "red fox")])
 
     assert %{"__value__" => true, "match" => "Fox"} == Eval.eval!(ast, %{})
+
+    {:ok, ast, "", _, _, _} = Parser.parse(~s[@or(1 == 1, has_all_words("Red Fox", "red fox"))])
+
+    assert true == Eval.eval!(ast, %{})
   end
 
   test "if" do


### PR DESCRIPTION
Add support for numbers in `has_all_words/2` from the Standard callbacks module. Also, add a refactor to evaluate `:function` expressions in a lazy fashion.