### PR TITLE
Bug/sc 20121/schmidt formative assessment playbook throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 2.23.7"}
+    {:expression, "~> 2.23.8"}
   ]
 end
 ```

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -83,7 +83,9 @@ defmodule Expression do
     String.replace(expression, ~r/@([a-z]+)(\(|\.)?/i, "@@\\g{1}\\g{2}")
   end
 
-  @spec parse!(String.t()) :: Keyword.t()
+  @spec parse!(String.t() | Number.t()) :: Keyword.t()
+  def parse!(expression) when is_number(expression), do: to_string(expression) |> parse!()
+
   def parse!(expression) do
     case Parser.parse(expression) do
       {:ok, ast, "", _, _, _} ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "2.23.7"
+  @version "2.23.8"
 
   def project do
     [

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -33,6 +33,8 @@ defmodule ExpressionTest do
       assert "1.23" == Expression.evaluate_as_string!("@(1.23)")
       assert "2022-06-28" == Expression.evaluate_as_string!("@date(2022, 6, 28)")
       assert "123" == Expression.evaluate_as_string!("@([1,2,3])")
+      assert "1" == Expression.evaluate_as_string!(1)
+      assert "1.5" == Expression.evaluate_as_string!(1.5)
     end
 
     test "list with attribute" do


### PR DESCRIPTION
Fix `Expression.parse!/1` to handle numbers.

Story details: [Shortcut Story #20121: Schmidt: Formative Assessment Playbook throws an error when using numbers as option answers](https://app.shortcut.com/turn-io/story/20121/schmidt-formative-assessment-playbook-throws-an-error-when-using-numbers-as-option-answers).