### PR TITLE
[sc-20121] fix(expression): parse! to handle numbers

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -83,7 +83,9 @@ defmodule Expression do
     String.replace(expression, ~r/@([a-z]+)(\(|\.)?/i, "@@\\g{1}\\g{2}")
   end
 
-  @spec parse!(String.t()) :: Keyword.t()
+  @spec parse!(String.t() | Number.t()) :: Keyword.t()
+  def parse!(expression) when is_number(expression), do: to_string(expression) |> parse!()
+
   def parse!(expression) do
     case Parser.parse(expression) do
       {:ok, ast, "", _, _, _} ->

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -33,6 +33,8 @@ defmodule ExpressionTest do
       assert "1.23" == Expression.evaluate_as_string!("@(1.23)")
       assert "2022-06-28" == Expression.evaluate_as_string!("@date(2022, 6, 28)")
       assert "123" == Expression.evaluate_as_string!("@([1,2,3])")
+      assert "1" == Expression.evaluate_as_string!(1)
+      assert "1.5" == Expression.evaluate_as_string!(1.5)
     end
 
     test "list with attribute" do


### PR DESCRIPTION
Fix `Expression.parse!/1` to handle numbers.