### PR TITLE
handle empty list evaluation

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -92,6 +92,8 @@ defmodule Expression.Eval do
   def eval!({:range, [first, last, step]}, _context, _mod),
     do: Range.new(first, last, step)
 
+  def eval!({:list, []}, _context, _mod), do: []
+
   def eval!({:list, [{:args, ast}]}, context, mod) do
     ast
     |> Enum.reduce([], &[eval!(&1, context, mod) | &2])

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -142,6 +142,11 @@ defmodule Expression.EvalTest do
   end
 
   describe "lists" do
+    test "empty list" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@[]")
+      assert [] == Eval.eval!(ast, %{})
+    end
+
     test "with integer indices" do
       {:ok, ast, "", _, _, _} = Parser.parse("@foo[1]")
 


### PR DESCRIPTION
We're not handling `[]` properly, it breaks because the reducer assumes lists will always have members.