### PR TITLE
Extend has_phrase function to support nils and numbers

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1280,7 +1280,7 @@ defmodule Expression.Callbacks.Standard do
   def has_only_phrase(ctx, expression, phrase) do
     [expression, phrase] = eval_args!([expression, phrase], ctx)
 
-    case Enum.map([expression, phrase], &String.downcase/1) do
+    case Enum.map([expression, phrase], fn argument -> String.downcase(to_string(argument)) end) do
       # Future match result: expression
       [same, same] -> true
       _anything_else -> false

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1360,8 +1360,8 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "has_phrase(\"the quick brown fox\", \"\")", result: true
   def has_phrase(ctx, expression, phrase) do
     [expression, phrase] = eval_args!([expression, phrase], ctx)
-    lower_expression = String.downcase(expression)
-    lower_phrase = String.downcase(phrase)
+    lower_expression = String.downcase(to_string(expression))
+    lower_phrase = String.downcase(to_string(phrase))
     found? = String.contains?(lower_expression, lower_phrase)
     # Future match result: phrase
     found?

--- a/lib/expression/v2/callbacks/standard.ex
+++ b/lib/expression/v2/callbacks/standard.ex
@@ -1166,7 +1166,7 @@ defmodule Expression.V2.Callbacks.Standard do
                   result: false
 
   def has_only_phrase(_ctx, expression, phrase) do
-    case Enum.map([expression, phrase], &String.downcase/1) do
+    case Enum.map([expression, phrase], fn argument -> String.downcase(to_string(argument)) end) do
       # Future match result: expression
       [same, same] -> true
       _anything_else -> false

--- a/lib/expression/v2/callbacks/standard.ex
+++ b/lib/expression/v2/callbacks/standard.ex
@@ -1240,8 +1240,8 @@ defmodule Expression.V2.Callbacks.Standard do
   @expression_doc expression: "has_phrase(\"the quick brown fox\", \"quick fox\")", result: false
   @expression_doc expression: "has_phrase(\"the quick brown fox\", \"\")", result: true
   def has_phrase(_ctx, expression, phrase) do
-    lower_expression = String.downcase(expression)
-    lower_phrase = String.downcase(phrase)
+    lower_expression = String.downcase(to_string(expression))
+    lower_phrase = String.downcase(to_string(phrase))
     found? = String.contains?(lower_expression, lower_phrase)
     # Future match result: phrase
     found?

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -21,6 +21,12 @@ defmodule ExpressionTest do
                Expression.evaluate_as_boolean!("@has_phrase(contact.number, \"456\")", %{
                  "contact" => %{"number" => 123_456}
                })
+
+      assert true == Expression.evaluate_as_boolean!("@has_only_phrase('foo bar', 'foo bar')")
+      assert false == Expression.evaluate_as_boolean!("@has_only_phrase('foo bar baz', 'foo bar')")
+
+      assert false ==
+        Expression.evaluate_as_boolean!("@has_only_phrase(name, 'bar')", %{"name" => nil})
     end
 
     test "list with indices" do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -13,8 +13,14 @@ defmodule ExpressionTest do
       assert true == Expression.evaluate_as_boolean!("@and(has_all_words('foo', 'foo'), true)")
       assert true == Expression.evaluate_as_boolean!("@has_phrase('foo', 'foo')")
       assert false == Expression.evaluate_as_boolean!("@has_phrase('foo', 'bar')")
-      assert false == Expression.evaluate_as_boolean!("@has_phrase(name, 'bar')", %{"name" => nil})
-      assert true == Expression.evaluate_as_boolean!("@has_phrase(contact.number, \"456\")", %{"contact" => %{"number" => 123_456}})
+
+      assert false ==
+               Expression.evaluate_as_boolean!("@has_phrase(name, 'bar')", %{"name" => nil})
+
+      assert true ==
+               Expression.evaluate_as_boolean!("@has_phrase(contact.number, \"456\")", %{
+                 "contact" => %{"number" => 123_456}
+               })
     end
 
     test "list with indices" do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -2,17 +2,21 @@ defmodule ExpressionTest do
   use ExUnit.Case, async: true
   doctest Expression
 
-  describe "evaluate_as_boolean!" do
-    assert true == Expression.evaluate_as_boolean!("@(tRuE)")
-    assert false == Expression.evaluate_as_boolean!("@(fAlSe)")
-    assert true == Expression.evaluate_as_boolean!("@(1 > 0)")
-    assert true == Expression.evaluate_as_boolean!("@has_all_words('foo', 'foo')")
-    assert true == Expression.evaluate_as_boolean!("@or(has_all_words('foo', 'bar'), true)")
-    assert false == Expression.evaluate_as_boolean!("@and(has_all_words('foo', 'bar'), true)")
-    assert true == Expression.evaluate_as_boolean!("@and(has_all_words('foo', 'foo'), true)")
-  end
-
   describe "evaluate" do
+    test "evaluate_as_boolean!" do
+      assert true == Expression.evaluate_as_boolean!("@(tRuE)")
+      assert false == Expression.evaluate_as_boolean!("@(fAlSe)")
+      assert true == Expression.evaluate_as_boolean!("@(1 > 0)")
+      assert true == Expression.evaluate_as_boolean!("@has_all_words('foo', 'foo')")
+      assert true == Expression.evaluate_as_boolean!("@or(has_all_words('foo', 'bar'), true)")
+      assert false == Expression.evaluate_as_boolean!("@and(has_all_words('foo', 'bar'), true)")
+      assert true == Expression.evaluate_as_boolean!("@and(has_all_words('foo', 'foo'), true)")
+      assert true == Expression.evaluate_as_boolean!("@has_phrase('foo', 'foo')")
+      assert false == Expression.evaluate_as_boolean!("@has_phrase('foo', 'bar')")
+      assert false == Expression.evaluate_as_boolean!("@has_phrase(name, 'bar')", %{"name" => nil})
+      assert true == Expression.evaluate_as_boolean!("@has_phrase(contact.number, \"456\")", %{"contact" => %{"number" => 123_456}})
+    end
+
     test "list with indices" do
       assert "bar" == Expression.evaluate_as_string!("@foo[1]", %{"foo" => ["baz", "bar"]})
     end

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -23,10 +23,12 @@ defmodule ExpressionTest do
                })
 
       assert true == Expression.evaluate_as_boolean!("@has_only_phrase('foo bar', 'foo bar')")
-      assert false == Expression.evaluate_as_boolean!("@has_only_phrase('foo bar baz', 'foo bar')")
 
       assert false ==
-        Expression.evaluate_as_boolean!("@has_only_phrase(name, 'bar')", %{"name" => nil})
+               Expression.evaluate_as_boolean!("@has_only_phrase('foo bar baz', 'foo bar')")
+
+      assert false ==
+               Expression.evaluate_as_boolean!("@has_only_phrase(name, 'bar')", %{"name" => nil})
     end
 
     test "list with indices" do


### PR DESCRIPTION
The `has_phrase` callback currently throws an exception if any of the arguments are null or integers.

This PR extends `has_phrase` to support null values and integer values too.