### PR TITLE
Fix concatenation with default values

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -501,7 +501,9 @@ defmodule Expression.Callbacks.Standard do
                   },
                   result: "name surname"
   def concatenate_vargs(ctx, arguments) do
-    Enum.join(eval_args!(arguments, ctx), "")
+    arguments
+    |> eval_args!(ctx)
+    |> Enum.map_join("", &Expression.Eval.default_value/1)
   end
 
   @doc """

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -86,6 +86,22 @@ defmodule Expression.EvalTest do
     assert true == Eval.eval!(ast, %{})
   end
 
+  test "concatenate with default values" do
+    now = "2023-12-07T09:47:27.234912Z"
+
+    ctx = %{
+      "flow" => %{
+        "date" => now,
+        "time" => "09:30:00"
+      }
+    }
+
+    {:ok, ast, "", _, _, _} =
+      Parser.parse(~s|@concatenate(datevalue(flow.date, "%Y-%m-%d"), "T", flow.time)|)
+
+    assert "2023-12-07T09:30:00" == Eval.eval!(ast, ctx)
+  end
+
   test "if" do
     {:ok, ast, "", _, _, _} =
       Parser.parse("@if(image_response.status == 200,\nimage_response.body.id,\nfalse)")


### PR DESCRIPTION
`datevalue(now(), "%Y-%m-%d")` returns a complex value:

```elixir
iex(1)> Expression.evaluate_block("datevalue(now(), \"%Y-%m-%d\")")
{:ok, %{"__value__" => "2023-12-07", "date" => ~U[2023-12-07 09:50:34.053039Z]}}
```

If we use that in `concatenate(datevalue(thing.date, "%Y-%m-%d"), "T", thing.time)` to construct a new datetime then it fails because it tries to join the complex value rather than the default value.

This fixes that by retrieving the default value before attempting to join things.