### PR TITLE
use datetime for datevalue function

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -112,7 +112,11 @@ defmodule Expression.Callbacks.Standard do
   """
   @expression_doc doc: "Convert a date from a piece of text to a formatted date string",
                   expression: "datevalue(\"2022-01-01\")",
-                  result: %{"__value__" => "2022-01-01 00:00:00", "date" => ~D[2022-01-01]}
+                  result: %{
+                    "__value__" => "2022-01-01 00:00:00",
+                    "date" => ~D[2022-01-01],
+                    "datetime" => ~U[2022-01-01 00:00:00Z]
+                  }
   @expression_doc doc: "Convert a date from a piece of text and read the date field",
                   expression: "datevalue(\"2022-01-01\").date",
                   result: ~D[2022-01-01]

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -122,17 +122,22 @@ defmodule Expression.Callbacks.Standard do
   def datevalue(ctx, date, format) do
     [date, format] = eval!([date, format], ctx)
 
-    if date = DateHelpers.extract_dateish(date) do
-      %{"__value__" => Timex.format!(date, format, :strftime), "date" => date}
+    if datetime = DateHelpers.extract_datetimeish(date) do
+      %{
+        "__value__" => Timex.format!(datetime, format, :strftime),
+        "date" => DateTime.to_date(datetime),
+        "datetime" => datetime
+      }
     end
   end
 
   def datevalue(ctx, date) do
-    date = DateHelpers.extract_dateish(eval!(date, ctx))
+    datetime = DateHelpers.extract_datetimeish(eval!(date, ctx))
 
     %{
-      "__value__" => Timex.format!(date, "%Y-%m-%d %H:%M:%S", :strftime),
-      "date" => date
+      "__value__" => Timex.format!(datetime, "%Y-%m-%d %H:%M:%S", :strftime),
+      "date" => DateTime.to_date(datetime),
+      "datetime" => datetime
     }
   end
 

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -97,9 +97,10 @@ defmodule Expression.EvalTest do
     }
 
     {:ok, ast, "", _, _, _} =
-      Parser.parse(~s|@concatenate(datevalue(flow.date, "%Y-%m-%d"), "T", flow.time)|)
+      Parser.parse(~s|@datevalue(concatenate(datevalue(flow.date, "%Y-%m-%d"), "T", flow.time))|)
 
-    assert "2023-12-07T09:30:00" == Eval.eval!(ast, ctx)
+    assert ~U[2023-12-07 09:30:00.0Z] == Eval.eval!(ast, ctx)["datetime"]
+    assert ~D[2023-12-07] == Eval.eval!(ast, ctx)["date"]
   end
 
   test "if" do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -140,7 +140,11 @@ defmodule ExpressionTest do
     end
 
     test "operators against default values" do
-      assert %{"__value__" => to_string(Date.utc_today()), "date" => Date.utc_today()} ==
+      assert %{
+               "__value__" => to_string(Date.utc_today()),
+               "date" => Date.utc_today(),
+               "datetime" => Timex.beginning_of_day(DateTime.utc_now())
+             } ==
                Expression.evaluate_block!("datevalue(today(), '%Y-%m-%d')")
 
       assert Expression.evaluate_block!("date == today()", %{


### PR DESCRIPTION
When giving this function a datetime value we drop the `%H:%m:%s` precision because we're treating it as a date.
This has it work with datetime internally and assumes `00:00:00` when no time is present.