### PR TITLE
return matched values on has_* functions

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1378,7 +1378,7 @@ defmodule Expression.Callbacks.Standard do
     parse_phone_number(letters_removed, country_code)
   end
 
-  def parse_phone_number(string, country_code) do
+  defp parse_phone_number(string, country_code) do
     pn =
       case ExPhoneNumber.parse(string, country_code) do
         {:ok, pn} -> ExPhoneNumber.format(pn, :e164)


### PR DESCRIPTION
Knowing that we found something is great, having access to it is greater.

when we do `has_number("some multiple of 8")` this will return:

```elixir
%{"__value__" => true, "number" => 8.0}
```

and so it can be used as a test function as its default value is `true` but one can also read the matched number with `.number`