### PR TITLE
do not break validation on built-in operators

### DIFF
--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -20,6 +20,7 @@ defmodule Expression.Callbacks do
 
   alias Expression.Callbacks.Standard
 
+  @built_in_operators [:+, :-, :*, :/, :>, :>=, :<, :<=, :==, :!=]
   @reserved_words ~w[and if or not]
 
   @doc """
@@ -73,6 +74,9 @@ defmodule Expression.Callbacks do
     |> Enum.each(&Code.ensure_loaded!/1)
 
     cond do
+      exact_function_name in @built_in_operators ->
+        {:exact, module, exact_function_name, 2}
+
       # Check if the exact function signature has been implemented
       function_exported?(module, exact_function_name, length(arguments) + 1) ->
         {:exact, module, exact_function_name, length(arguments) + 1}

--- a/test/expression_custom_callbacks_test.exs
+++ b/test/expression_custom_callbacks_test.exs
@@ -11,12 +11,70 @@ defmodule ExpressionCustomCallbacksTest do
       "You said #{inspect(value)}"
     end
 
+    def length_vargs(_ctx, args) do
+      Enum.count(args)
+    end
+
     def count(ctx, value) do
       case eval!(value, ctx) do
         string when is_binary(string) -> String.length(string)
         list when is_list(list) -> length(list)
         other -> Enum.count(other)
       end
+    end
+  end
+
+  describe "implements" do
+    test "defined functions" do
+      assert {:exact, ExpressionCustomCallbacksTest.CustomCallback, :echo, 2} ==
+               Expression.Callbacks.implements(
+                 ExpressionCustomCallbacksTest.CustomCallback,
+                 "echo",
+                 [1]
+               )
+    end
+
+    test "undefined functions" do
+      assert {:error, "boo is not implemented."} ==
+               Expression.Callbacks.implements(
+                 ExpressionCustomCallbacksTest.CustomCallback,
+                 "boo",
+                 [1]
+               )
+    end
+
+    test "wrong arity functions" do
+      assert {:error, "echo is not implemented."} ==
+               Expression.Callbacks.implements(
+                 ExpressionCustomCallbacksTest.CustomCallback,
+                 "echo",
+                 [1, 2, 3]
+               )
+    end
+
+    test "variable args functions" do
+      assert {:vargs, ExpressionCustomCallbacksTest.CustomCallback, :length_vargs, 2} ==
+               Expression.Callbacks.implements(
+                 ExpressionCustomCallbacksTest.CustomCallback,
+                 "length",
+                 [1, 2, 3]
+               )
+
+      assert {:vargs, ExpressionCustomCallbacksTest.CustomCallback, :length_vargs, 2} ==
+               Expression.Callbacks.implements(
+                 ExpressionCustomCallbacksTest.CustomCallback,
+                 "length",
+                 []
+               )
+    end
+
+    test "built in operators" do
+      assert {:exact, ExpressionCustomCallbacksTest.CustomCallback, :!=, 2} =
+               Expression.Callbacks.implements(
+                 ExpressionCustomCallbacksTest.CustomCallback,
+                 "!=",
+                 [1, 1]
+               )
     end
   end
 


### PR DESCRIPTION
Now that we're doing more complete validation in areas of Turn this issue has surfaced.