### PR TITLE
Support non-string values in has_beginning

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1008,7 +1008,7 @@ defmodule Expression.Callbacks.Standard do
   def has_beginning(ctx, text, beginning) do
     [text, beginning] = eval_args!([text, beginning], ctx)
 
-    case Regex.run(~r/^#{Regex.escape(beginning)}/i, text) do
+    case Regex.run(~r/^#{Regex.escape(beginning)}/i, to_string(text)) do
       # future match result: first
       [_first | _remainder] -> true
       nil -> false

--- a/lib/expression/v2/callbacks/standard.ex
+++ b/lib/expression/v2/callbacks/standard.ex
@@ -878,7 +878,7 @@ defmodule Expression.V2.Callbacks.Standard do
                   result: false
   @expression_doc expression: "has_beginning(\"The Quick Brown\", \"quick brown\")", result: false
   def has_beginning(_ctx, text, beginning) do
-    case Regex.run(~r/^#{Regex.escape(beginning)}/i, text) do
+    case Regex.run(~r/^#{Regex.escape(beginning)}/i, to_string(text)) do
       # future match result: first
       [_first | _remainder] -> true
       nil -> false

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -29,6 +29,11 @@ defmodule ExpressionTest do
 
       assert false ==
                Expression.evaluate_as_boolean!("@has_only_phrase(name, 'bar')", %{"name" => nil})
+
+      assert true ==
+               Expression.evaluate_as_boolean!("@has_beginning(contact.number, \"123\")", %{
+                 "contact" => %{"number" => 123_456}
+               })
     end
 
     test "list with indices" do


### PR DESCRIPTION
Ensure that `has_beginning` does not break on non-string values (such as numeric values).
The same was done for `has_phrase` in https://github.com/turnhub/expression/pull/156