### PR TITLE
Allow comparing date/datetimes to ISO8601 date/datetime strings

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         elixir: ["1.15"]
         otp: ["26"]
+        cache_version: ["1"]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,8 +26,8 @@ jobs:
         id: mix-cache
         with:
           path: deps
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-mix-
+          key: ${{matrix.cache_version}}-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{matrix.cache_version}}-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
       - name: Install Mix Dependencies
         if: steps.mix-cache.outputs.cache-hit != 'true'
         run: |
@@ -42,7 +43,7 @@ jobs:
         id: plt-cache
         with:
           path: .plts
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          key: ${{matrix.cache_version}}-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - name: Create PLTs
         if: steps.plt-cache.outputs.cache-hit != 'true'
         run: |

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -198,6 +198,7 @@ defmodule Expression.Eval do
   def op(:=, a, b) when is_struct(a, Date) and is_struct(b, Date),
     do: Date.compare(a, b) == :eq
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def op(operator, a, b)
       when operator in [:=, :==, :!=, :<, :<=, :>, :>=] and
              (is_struct(a, Date) or is_struct(a, DateTime)) and

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -259,6 +259,9 @@ defmodule Expression.EvalTest do
       {:ok, ast, "", _, _, _} = Parser.parse("@(a == \"2024-01-01\")")
       assert true == Eval.eval!(ast, %{"a" => ~D[2024-01-01]})
 
+      {:ok, ast, "", _, _, _} = Parser.parse("@(\"2024-01-01\" == a)")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2024-01-01]})
+
       {:ok, ast, "", _, _, _} = Parser.parse("@(a = \"2024-01-01\")")
       assert true == Eval.eval!(ast, %{"a" => ~D[2024-01-01]})
 

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -279,6 +279,9 @@ defmodule Expression.EvalTest do
       {:ok, ast, "", _, _, _} = Parser.parse("@(a < \"2019-01-01\")")
       assert false == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
 
+      {:ok, ast, "", _, _, _} = Parser.parse("@(\"2019-01-01\" < a)")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+
       {:ok, ast, "", _, _, _} = Parser.parse("@(a < \"2019-01-01\")")
       assert false == Eval.eval!(ast, %{"a" => ~D[2019-01-01]})
     end

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -253,4 +253,134 @@ defmodule Expression.EvalTest do
                "contact" => %{"name" => "Bob"}
              })
   end
+
+  describe "comparing dates and ISO8601 strings" do
+    test "using ==, =, != to compare a date an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a == \"2024-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2024-01-01]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a = \"2024-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2024-01-01]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a != \"2024-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2024-01-04]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a != \"2024-01-01\")")
+      assert false == Eval.eval!(ast, %{"a" => ~D[2024-01-01]})
+    end
+
+    test "using < to compare a date to an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a < \"2024-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a < \"2019-01-01\")")
+      assert false == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a < \"2019-01-01\")")
+      assert false == Eval.eval!(ast, %{"a" => ~D[2019-01-01]})
+    end
+
+    test "using <= to compare a date to an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a <= \"2024-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a <= \"2019-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2019-01-01]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a <= \"2019-01-01\")")
+      assert false == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+    end
+
+    test "using > to compare a date to an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a > \"2024-01-01\")")
+      assert false == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a > \"2019-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a > \"2019-01-01\")")
+      assert false == Eval.eval!(ast, %{"a" => ~D[2019-01-01]})
+    end
+
+    test "using >= to compare a date to an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a >= \"2024-01-01\")")
+      assert false == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a >= \"2019-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2019-01-01]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a >= \"2019-01-01\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+    end
+
+    test "a date can be compared to an ISO8601 string representation of a datetime" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a <= \"2020-11-16T10:40:50.277482Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~D[2020-11-16]})
+    end
+  end
+
+  describe "comparing datetimes and ISO8601 strings" do
+    test "using ==, =, != to compare a date an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a == \"2024-01-01T10:40:50.277482Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2024-01-01 10:40:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a = \"2024-01-01T10:40:50.277483Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2024-01-01 10:40:50.277483Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a != \"2024-01-01T10:40:50.277484Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2024-01-04 10:40:50.277484Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a != \"2024-01-01T10:40:50.277485Z\")")
+      assert false == Eval.eval!(ast, %{"a" => ~U[2024-01-01 10:40:50.277485Z]})
+    end
+
+    test "using < to compare a date to an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a < \"2024-01-01T10:40:50.277482Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2024-01-01 10:39:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a < \"2019-01-01T10:40:50.277482Z\")")
+      assert false == Eval.eval!(ast, %{"a" => ~U[2020-11-16 10:40:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a < \"2019-01-01T10:40:50.277482Z\")")
+      assert false == Eval.eval!(ast, %{"a" => ~U[2019-01-01 10:40:50.277482Z]})
+    end
+
+    test "using <= to compare a date to an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a <= \"2024-01-01T10:40:50.277482Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2020-11-16 10:40:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a <= \"2019-01-01T10:40:50.277482Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2019-01-01 10:40:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a <= \"2019-01-01T10:40:50.277482Z\")")
+      assert false == Eval.eval!(ast, %{"a" => ~U[2020-11-16 10:40:50.277482Z]})
+    end
+
+    test "using > to compare a date to an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a > \"2024-01-01T10:40:50.277482Z\")")
+      assert false == Eval.eval!(ast, %{"a" => ~U[2020-11-16 10:40:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a > \"2019-01-01T10:40:50.277482Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2020-11-16 10:40:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a > \"2019-01-01T10:40:50.277482Z\")")
+      assert false == Eval.eval!(ast, %{"a" => ~U[2019-01-01 10:40:50.277482Z]})
+    end
+
+    test "using >= to compare a date to an ISO8601 string representation of a date" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a >= \"2024-01-01T10:40:50.277482Z\")")
+      assert false == Eval.eval!(ast, %{"a" => ~U[2020-11-16 10:40:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a >= \"2019-01-01T10:40:50.277482Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2019-01-01 10:40:50.277482Z]})
+
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a >= \"2019-01-01T10:40:50.277482Z\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2020-11-16 10:40:50.277482Z]})
+    end
+
+    test "a date can be compared to an ISO8601 string representation of a datetime" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@(a > \"2020-11-16\")")
+      assert true == Eval.eval!(ast, %{"a" => ~U[2023-11-16 10:40:50.277482Z]})
+    end
+  end
 end


### PR DESCRIPTION
This PR adds overloads for the `:=, :==, :!=, :<, :<=, :>, :>=` boolean operators to allows users to compare `Date` or `DateTime` values with ISO8601 string representations of dates and datetimes.

Adding support for this kind of comparisons makes it much easier to create Triggers/Conditionals in Turn that compare a Contact's datetime field to a specific datetime value (expressed as an ISO8601 string).