### PR TITLE
Add flag to skip evaluation of literals in Context

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -96,13 +96,18 @@ defmodule Expression do
     end
   end
 
-  def evaluate_block!(expression, context \\ %{}, mod \\ Expression.Callbacks) do
+  def evaluate_block!(
+        expression,
+        context \\ %{},
+        mod \\ Expression.Callbacks,
+        opts \\ []
+      ) do
     ast = parse_expression!(expression)
-    Eval.eval!([expression: ast], Context.new(context), mod)
+    Eval.eval!([expression: ast], Context.new(context, opts), mod)
   end
 
-  def evaluate_block(expression, context \\ %{}, mod \\ Expression.Callbacks) do
-    {:ok, evaluate_block!(expression, context, mod)}
+  def evaluate_block(expression, context \\ %{}, mod \\ Expression.Callbacks, opts \\ []) do
+    {:ok, evaluate_block!(expression, context, mod, opts)}
   rescue
     e in RuntimeError -> {:error, e.message}
   end

--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -60,7 +60,7 @@ defmodule Expression.Context do
   defp iterate({key, value}, _), do: {key, value}
 
   defp evaluate!(ctx, opts) when is_map(ctx) and not is_struct(ctx) do
-    new(ctx, Keyword.put(opts, :recursive_call, true))
+    new(ctx, opts)
   end
 
   defp evaluate!(ctx, opts) when is_list(ctx) do

--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -34,35 +34,41 @@ defmodule Expression.Context do
   """
   @type t :: map
 
-  @spec new(map) :: t
-  def new(ctx) when is_map(ctx) do
+  @spec new(map, Keyword.t() | nil) :: t
+  def new(ctx, opts \\ []) when is_map(ctx) do
     ctx
     # Ensure all keys are lower case strings
     |> Enum.map(&downcase_string_key/1)
-    |> Enum.map(&iterate(&1))
+    |> Enum.map(&iterate(&1, opts))
     |> Enum.into(%{})
   end
 
   defp downcase_string_key({key, value}), do: {String.downcase(to_string(key)), value}
 
-  defp iterate({key, value}) when is_map(value) or is_list(value) do
-    {key, evaluate!(value)}
+  defp iterate({key, value}, opts) when is_map(value) or is_list(value) do
+    {key, evaluate!(value, opts)}
   end
 
-  defp iterate({key, value}) when is_binary(value), do: {key, evaluate!(value)}
-
-  defp iterate({key, value}), do: {key, value}
-
-  defp evaluate!(ctx) when is_map(ctx) and not is_struct(ctx) do
-    new(ctx)
+  defp iterate({key, value}, opts) when is_binary(value) do
+    if Keyword.get(opts, :skip_context_evaluation?, false) do
+      {key, value}
+    else
+      {key, evaluate!(value, opts)}
+    end
   end
 
-  defp evaluate!(ctx) when is_list(ctx) do
+  defp iterate({key, value}, _), do: {key, value}
+
+  defp evaluate!(ctx, opts) when is_map(ctx) and not is_struct(ctx) do
+    new(ctx, Keyword.put(opts, :recursive_call, true))
+  end
+
+  defp evaluate!(ctx, opts) when is_list(ctx) do
     ctx
-    |> Enum.map(&evaluate!(&1))
+    |> Enum.map(&evaluate!(&1, opts))
   end
 
-  defp evaluate!(binary) when is_binary(binary) do
+  defp evaluate!(binary, _) when is_binary(binary) do
     case Expression.Parser.literal(binary) do
       {:ok, [{:literal, literal}], "", _, _, _} -> literal
       # when we're not parsing the full literal
@@ -74,5 +80,5 @@ defmodule Expression.Context do
     ArgumentError -> binary
   end
 
-  defp evaluate!(value), do: value
+  defp evaluate!(value, _), do: value
 end

--- a/lib/expression/v2/compat.ex
+++ b/lib/expression/v2/compat.ex
@@ -134,11 +134,13 @@ defmodule Expression.V2.Compat do
   def evaluate_block!(
         expression,
         context \\ %{},
-        callback_module \\ Callbacks.Standard
+        callback_module \\ Callbacks.Standard,
+        opts \\ []
       )
 
-  def evaluate_block!(expression, context, callback_module) do
-    v1_resp = Expression.evaluate_block(expression, context, callback_module)
+  def evaluate_block!(expression, context, callback_module, opts) do
+    v1_resp =
+      Expression.evaluate_block(expression, context, callback_module, opts)
 
     # v2_resp =
     #   case V2.eval_block(

--- a/test/expression/context_test.exs
+++ b/test/expression/context_test.exs
@@ -16,4 +16,50 @@ defmodule Expression.ContextTest do
     assert %{"block" => %{"value" => %{"program_start_date" => ~U[2022-11-10 13:40:05.921378Z]}}} =
              Context.new(context)
   end
+
+  describe "context is parsed correctly when using the skip_context_evaluation? option" do
+    test "string values in context that resemble booleans should not be parsed as booleans" do
+      assert %{
+               "block" => %{"response" => "True"}
+             } ==
+               Context.new(
+                 %{
+                   "block" => %{"response" => "True"}
+                 },
+                 skip_context_evaluation?: true
+               )
+
+      assert %{
+               "block" => %{"response" => "true"}
+             } ==
+               Context.new(
+                 %{
+                   "block" => %{"response" => "true"}
+                 },
+                 skip_context_evaluation?: true
+               )
+    end
+
+    test "string values in context that resemble numbers should not be parsed as numbers" do
+      assert %{
+               "ref_buttons_7bef16" => %{
+                 "__value__" => "2",
+                 "index" => 1,
+                 "label" => "2",
+                 "name" => "2"
+               }
+             } ==
+               Context.new(
+                 %{
+                   "ref_Buttons_7bef16" => %{
+                     "__value__" => "2",
+                     "index" => 1,
+                     "label" => "2",
+                     "name" => "2"
+                   }
+                 },
+                 skip_context_evaluation?: true
+               )
+    end
+  end
 end

--- a/test/expression/context_test.exs
+++ b/test/expression/context_test.exs
@@ -17,25 +17,23 @@ defmodule Expression.ContextTest do
              Context.new(context)
   end
 
-  describe "context is parsed correctly when using the skip_context_evaluation? option" do
+  describe "context is parsed correctly when using the `skip_context_evaluation?` option" do
     test "string values in context that resemble booleans should not be parsed as booleans" do
-      assert %{
-               "block" => %{"response" => "True"}
-             } ==
-               Context.new(
-                 %{
-                   "block" => %{"response" => "True"}
-                 },
+      # By default (without the flag) boolean-ish string values as parsed as booleans
+      assert %{"block" => %{"response" => true}} ==
+               Context.new(%{
+                 "block" => %{"response" => "True"}
+               })
+
+      # With the flag set to true they are kept as strings
+      assert %{"block" => %{"response" => "True"}} ==
+               Context.new(%{"block" => %{"response" => "True"}},
                  skip_context_evaluation?: true
                )
 
-      assert %{
-               "block" => %{"response" => "true"}
-             } ==
+      assert %{"block" => %{"response" => "true"}} ==
                Context.new(
-                 %{
-                   "block" => %{"response" => "true"}
-                 },
+                 %{"block" => %{"response" => "true"}},
                  skip_context_evaluation?: true
                )
     end

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -418,4 +418,35 @@ defmodule ExpressionTest do
     assert "@@if(foo, bar, baz)" == Expression.escape("@if(foo, bar, baz)")
     assert "@@if(foo, bar.baz, baz)" == Expression.escape("@if(foo, bar.baz, baz)")
   end
+
+  describe "context is parsed correctly when using the skip_context_evaluation? option" do
+    test "string values in context that resemble booleans should not be parsed as booleans" do
+      assert true ==
+               Expression.evaluate_block!(
+                 "block.response = \"True\"",
+                 %{
+                   "block" => %{"response" => "True"}
+                 },
+                 Expression.Callbacks,
+                 skip_context_evaluation?: true
+               )
+    end
+
+    test "string values in context that resemble numbers should not be parsed as numbers" do
+      assert true ==
+               Expression.evaluate_block!(
+                 "ref_Buttons_7bef16 == \"2\"",
+                 %{
+                   "ref_Buttons_7bef16" => %{
+                     "__value__" => "2",
+                     "index" => 1,
+                     "label" => "2",
+                     "name" => "2"
+                   }
+                 },
+                 Expression.Callbacks,
+                 skip_context_evaluation?: true
+               )
+    end
+  end
 end


### PR DESCRIPTION
Expression v1 evaluates every literal in Context and parses strings resembling booleans (e.g. `"True"`) into booleans and strings resembling numbers (e.g. `"123"`) into numbers.

That's not what we always want, in fact we don't do that anymore in Expression V2. This PR adds an optional flag to `Expression.Expression.evaluate_block!` that allows turning off the automatic parsing of the Context literals.