### PR TITLE
do not crash on extracting date-ish things

### DIFF
--- a/lib/date_helpers.ex
+++ b/lib/date_helpers.ex
@@ -176,8 +176,7 @@ defmodule Expression.DateHelpers do
     end
   end
 
-  @spec extract_datetimeish(DateTime.t() | Date.t() | String.t() | nil) :: DateTime.t() | nil
-  def extract_datetimeish(nil), do: nil
+  @spec extract_datetimeish(DateTime.t() | Date.t() | String.t() | term) :: DateTime.t() | nil
   def extract_datetimeish(date_time) when is_struct(date_time, DateTime), do: date_time
 
   def extract_datetimeish(date) when is_struct(date, Date),
@@ -197,6 +196,8 @@ defmodule Expression.DateHelpers do
         nil
     end
   end
+
+  def extract_datetimeish(_term), do: nil
 
   @spec extract_timeish(DateTime.t() | Time.t() | String.t()) :: Time.t() | nil
   def extract_timeish(datetime) when is_struct(datetime, DateTime),

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1064,6 +1064,21 @@ defmodule Expression.Callbacks.Standard do
                     "date" => nil,
                     "datetime" => nil
                   }
+  @expression_doc expression: "has_date(1)",
+                  result: %{
+                    "__value__" => false,
+                    "date" => nil,
+                    "datetime" => nil,
+                    "match" => nil
+                  }
+  @expression_doc expression: "has_date(var)",
+                  context: %{"var" => 1},
+                  result: %{
+                    "__value__" => false,
+                    "date" => nil,
+                    "datetime" => nil,
+                    "match" => nil
+                  }
   def has_date(ctx, expression) do
     {date, datetime} =
       if datetime = DateHelpers.extract_datetimeish(eval!(expression, ctx)) do


### PR DESCRIPTION
If an integer was supplied it would hit an unsupported code path rather than returning `nil` like it should.