### PR TITLE
fix(context): parsing zero as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 2.36.0"}
+    {:expression, "~> 2.36.1"}
   ]
 end
 ```

--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -49,14 +49,15 @@ defmodule Expression.Context do
     {key, evaluate!(value, opts)}
   end
 
-  # Prevent implictly converting numbers starting with a zero
+  # Implictly convert the string "0" as a number
   defp iterate({key, "0"}, _opts), do: {key, 0}
 
+  # Prevent implictly converting numbers starting with a zero
   defp iterate({key, "0" <> value}, opts) when is_binary(value) do
     if String.match?("0" <> value, ~r/^[0-9]/) do
       {key, "0" <> value}
     else
-      iterate({key, "0" <> value}, opts)
+      iterate({key, value}, opts)
     end
   end
 

--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -50,11 +50,13 @@ defmodule Expression.Context do
   end
 
   # Prevent implictly converting numbers starting with a zero
+  defp iterate({key, "0"}, _opts), do: {key, 0}
+
   defp iterate({key, "0" <> value}, opts) when is_binary(value) do
     if String.match?("0" <> value, ~r/^[0-9]/) do
       {key, "0" <> value}
     else
-      iterate({key, value}, opts)
+      iterate({key, "0" <> value}, opts) |> dbg()
     end
   end
 

--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -56,7 +56,7 @@ defmodule Expression.Context do
     if String.match?("0" <> value, ~r/^[0-9]/) do
       {key, "0" <> value}
     else
-      iterate({key, "0" <> value}, opts) |> dbg()
+      iterate({key, "0" <> value}, opts)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "2.36.0"
+  @version "2.36.1"
 
   def project do
     [

--- a/test/expression/context_test.exs
+++ b/test/expression/context_test.exs
@@ -29,6 +29,11 @@ defmodule Expression.ContextTest do
     end
   end
 
+  test "new context with zero as a string" do
+    # Assert that the string "0" is parsed as a number
+    assert Context.new(%{"zero" => "0"}) == %{"zero" => 0}
+  end
+
   test "new context from a context containing a string starting with zero" do
     values = [
       %{"national_id" => "01234567"},

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -99,6 +99,7 @@ defmodule ExpressionTest do
     end
 
     test "list with indices" do
+      assert "baz" == Expression.evaluate_as_string!("@foo[0]", %{"foo" => ["baz", "bar"]})
       assert "bar" == Expression.evaluate_as_string!("@foo[1]", %{"foo" => ["baz", "bar"]})
     end
 
@@ -108,6 +109,25 @@ defmodule ExpressionTest do
                  "foo" => ["baz", "bar"],
                  "cursor" => 1
                })
+
+      assert "hello" ==
+               Expression.evaluate_block!("content_units_response.body[current_activity]", %{
+                 "content_units_response" => %{
+                   "body" => ["hello", "bye"]
+                 },
+                 "current_activity" => 0
+               })
+
+      assert "hello" ==
+               Expression.evaluate_block!(
+                 "content_units_response.body[current_activity]",
+                 %{
+                   "content_units_response" => %{
+                     "body" => ["hello", "bye"]
+                   },
+                   "current_activity" => "0"
+                 }
+               )
     end
 
     test "stringify primitives" do


### PR DESCRIPTION
Fix context parsing with zero as a string.