### PR TITLE
fix(eval): parse_number()

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -264,16 +264,15 @@ defmodule Expression.Eval do
   def parse_number(%{"__value__" => value}), do: parse_number(value)
 
   def parse_number(value) when is_binary(value) do
-    case Decimal.parse(value) do
-      {decimal, _} ->
-        if Decimal.integer?(decimal) do
-          Decimal.to_integer(decimal)
-        else
-          Decimal.to_float(decimal)
-        end
-
-      :error ->
-        value
+    with {_integer, _rem} <- Integer.parse(value),
+         {decimal, _rem} <- Decimal.parse(value) do
+      if Decimal.integer?(decimal) do
+        Decimal.to_integer(decimal)
+      else
+        Decimal.to_float(decimal)
+      end
+    else
+      _error -> value
     end
   end
 

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -96,6 +96,18 @@ defmodule ExpressionTest do
       assert true == Expression.evaluate_as_boolean!("@(1 * \"2\" == 2)")
       assert true == Expression.evaluate_as_boolean!("@(\"1\" * 2 == 2)")
       assert true == Expression.evaluate_as_boolean!("@(\"0.1\" * 0.2 == 0.020000000000000004)")
+
+      assert_raise RuntimeError, "expression is not a number: `\"NaN\"`", fn ->
+        Expression.evaluate_as_boolean!("@(1 * \"NaN\" == 2)")
+      end
+
+      assert_raise RuntimeError, "expression is not a number: `\"NaN\"`", fn ->
+        Expression.evaluate_as_boolean!("@(\"1\" * a == 2)", %{"a" => "NaN"})
+      end
+
+      assert_raise RuntimeError, "expression is not a number: `\"NaN\"`", fn ->
+        Expression.evaluate_as_boolean!("@(\"NaN\" * 0.2 == 0.02)")
+      end
     end
 
     test "list with indices" do


### PR DESCRIPTION
Fix `Expression.Eval.parse_number/1` when one of the given expressions is not a number at all.