### PR TITLE
Apply no_commas

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -573,7 +573,7 @@ defmodule Expression.Callbacks.Standard do
   ```
   """
   @expression_doc expression: "fixed(4.209922, 2, false)", result: "4.21"
-  @expression_doc expression: "fixed(4000.424242, 4, true)", result: "4,000.4242"
+  @expression_doc expression: "fixed(4000.424242, 4, true)", result: "4000.4242"
   @expression_doc expression: "fixed(3.7979, 2, false)", result: "3.80"
   @expression_doc expression: "fixed(3.7979, 2)", result: "3.80"
   @expression_doc expression: "fixed(0.0909, 2)", result: "0.09"
@@ -587,7 +587,7 @@ defmodule Expression.Callbacks.Standard do
       [number, precision, true] ->
         Number.Delimit.number_to_delimited(number,
           precision: precision,
-          delimiter: ",",
+          delimiter: "",
           separator: "."
         )
 


### PR DESCRIPTION
Even though we handle `no_commas` we pass it as the delimiter to the next call. This change makes `no_commas` work as expected.

Ticket: https://app.shortcut.com/turn-io/story/33620/fixed-number-precision-no-commas-returns-commas-in-the-result-even-when-the-no-commas-value-is-true

The fix works in the UI too:
![image](https://github.com/user-attachments/assets/78b55c72-a314-4400-a5f4-8bca49a15795)
