### PR TITLE
fix(eval): parse_number()

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -264,14 +264,8 @@ defmodule Expression.Eval do
   def parse_number(%{"__value__" => value}), do: parse_number(value)
 
   def parse_number(value) when is_binary(value) do
-    with {_integer, _rem} <- Integer.parse(value),
-         {decimal, _rem} <- Decimal.parse(value) do
-      if Decimal.integer?(decimal) do
-        Decimal.to_integer(decimal)
-      else
-        Decimal.to_float(decimal)
-      end
-    else
+    case Float.parse(value) do
+      {float, ""} -> float
       _error -> value
     end
   end

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -264,9 +264,15 @@ defmodule Expression.Eval do
   def parse_number(%{"__value__" => value}), do: parse_number(value)
 
   def parse_number(value) when is_binary(value) do
-    case Float.parse(value) do
-      {float, ""} -> float
-      _error -> value
+    case Integer.parse(value) do
+      {integer, ""} ->
+        integer
+
+      _other ->
+        case Float.parse(value) do
+          {float, ""} -> float
+          _error -> value
+        end
     end
   end
 

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -115,7 +115,7 @@ defmodule Expression.EvalTest do
 
   describe "lambdas" do
     test "with map" do
-      {:ok, ast, "", _, _, _} = Parser.parse("@map(foo, &([&1,'Button']))")
+      {:ok, ast, "", _, _, _} = Parser.parse("@map(foo, &([&1, 'Button']))")
 
       assert [[1, "Button"], [2, "Button"], [3, "Button"]] ==
                Eval.eval!(ast, %{"foo" => [1, 2, 3]})
@@ -136,6 +136,16 @@ defmodule Expression.EvalTest do
 
       assert [[1, "Button"], [2, "Button"], [3, "Button"]] ==
                Eval.eval!(ast, %{"foo" => [1, 2, 3]})
+    end
+
+    test "with kerner operators" do
+      {:ok, ast, "", _, _, _} = Parser.parse("@map(foo, &(&1 == \"1. selected\"))")
+
+      assert Eval.eval!(ast, %{"foo" => ["1. selected", "1. selected wrong", "other"]}) == [
+               true,
+               false,
+               false
+             ]
     end
 
     test "lambda with joins" do

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -138,7 +138,7 @@ defmodule Expression.EvalTest do
                Eval.eval!(ast, %{"foo" => [1, 2, 3]})
     end
 
-    test "with kerner operators" do
+    test "with kernel operators" do
       {:ok, ast, "", _, _, _} = Parser.parse("@map(foo, &(&1 == \"1. selected\"))")
 
       assert Eval.eval!(ast, %{"foo" => ["1. selected", "1. selected wrong", "other"]}) == [

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -97,8 +97,8 @@ defmodule ExpressionTest do
       assert true == Expression.evaluate_as_boolean!("@(\"1\" * 2 == 2)")
       assert true == Expression.evaluate_as_boolean!("@(\"0.1\" * 0.2 == 0.020000000000000004)")
 
-      assert true == Expression.evaluate_as_boolean!("@(\"1. A\" == \"1. A\")")
-      assert false == Expression.evaluate_as_boolean!("@(\"1. A\" == \"1. A wrong\")")
+      assert true == Expression.evaluate_as_boolean!("@(\"1. A\" == x)", %{"x" => "1. A"})
+      assert false == Expression.evaluate_as_boolean!("@(\"1. A wrong\" == x)", %{"x" => "1. A"})
 
       assert_raise RuntimeError, "expression is not a number: `\"NaN\"`", fn ->
         Expression.evaluate_as_boolean!("@(1 * \"NaN\" == 2)")

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -97,6 +97,9 @@ defmodule ExpressionTest do
       assert true == Expression.evaluate_as_boolean!("@(\"1\" * 2 == 2)")
       assert true == Expression.evaluate_as_boolean!("@(\"0.1\" * 0.2 == 0.020000000000000004)")
 
+      assert true == Expression.evaluate_as_boolean!("@(\"1. A\" == \"1. A\")")
+      assert false == Expression.evaluate_as_boolean!("@(\"1. A\" == \"1. A wrong\")")
+
       assert_raise RuntimeError, "expression is not a number: `\"NaN\"`", fn ->
         Expression.evaluate_as_boolean!("@(1 * \"NaN\" == 2)")
       end


### PR DESCRIPTION
Fix `Expression.Eval.parse_number/1` when handling strings combined with numbers and punctuations.