### PR TITLE
`has_number()` : handle `nil` and case when expression contain just a number

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1262,6 +1262,9 @@ defmodule Expression.Callbacks.Standard do
     !!group
   end
 
+  defp extract_numberish(nil), do: nil
+  defp extract_numberish(value) when is_number(value), do: value
+
   defp extract_numberish(expression) do
     with [match] <-
            Regex.run(~r/([0-9]+\.?[0-9]*)/u, replace_arabic_numerals(expression), capture: :first),

--- a/lib/expression/v2/callbacks/standard.ex
+++ b/lib/expression/v2/callbacks/standard.ex
@@ -1001,6 +1001,7 @@ defmodule Expression.V2.Callbacks.Standard do
     !!group
   end
 
+  defp extract_numberish(nil), do: nil
   defp extract_numberish(value) when is_number(value), do: value
 
   defp extract_numberish(expression) do
@@ -1054,6 +1055,8 @@ defmodule Expression.V2.Callbacks.Standard do
   @expression_doc expression: "has_number(\"العدد ٤٢\")", result: true
   @expression_doc expression: "has_number(\"٠.٥\")", result: true
   @expression_doc expression: "has_number(\"0.6\")", result: true
+  @expression_doc expression: "has_number(\"\")", result: false
+  @expression_doc expression: "has_number(value)", context: %{"value" => nil}, result: false
 
   def has_number(_ctx, expression) do
     number = extract_numberish(expression)


### PR DESCRIPTION
`has_number()` fails whether the input value is `nil`, such as:
```
iex> Expression.evaluate("@has_number(value)", %{"value" => nil})
** (FunctionClauseError) no function clause matching in String.replace/4
```

This PR extends `extract_numberish()` to handle `nil` input and cases when the expression contains just a number.
Examples that would fail without the edit:
```
iex> Expression.evaluate("The answer is @has_number(answer)", %{"answer" => nil})
{:ok, ["The answer is ", false]}
iex> Expression.evaluate("The answer is @has_number(answer)", %{"answer" => "42"})
{:ok, ["The answer is ", true]}
```

This is particularly needed because Expression does not implement lazy evaluation of the `and` boolean operator. As a result, we get errors every time a `nil` value is passed to `has_number()`, and we cannot fix it by simply adding a null check beforehand.
For instance, we get error here :
```
iex> Expression.evaluate("@and(isstring(value), has_number(value))", %{"value" => nil})
** (FunctionClauseError) no function clause matching in String.replace/4
```
The issue occurs because the entire expression is always evaluated, even if `isstring(nil)` results in `false` and the entire `and` would result in `false` anyway.