### PR TITLE
Fix: handle nil expression value on `has_pattern` function

### DIFF
--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1492,7 +1492,7 @@ defmodule Expression.Callbacks.Standard do
   def has_pattern(ctx, expression, pattern) do
     [expression, pattern] = eval_args!([expression, pattern], ctx)
 
-    with false <- is_nil(expression),
+    with true <- is_binary(expression),
          {:ok, regex} <- Regex.compile(String.trim(pattern), "i"),
          [[_first | _remainder]] <- Regex.scan(regex, String.trim(expression), capture: :all) do
       # Future match result: first

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1489,14 +1489,11 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "has_pattern(\"Buy cheese please\", \"buy (\\w+)\")", result: true
   @expression_doc expression: "has_pattern(\"Sell cheese please\", \"buy (\\w+)\")", result: false
   @expression_doc expression: "has_pattern(nil, \"buy (\\w+)\")", result: false
-  def has_pattern(nil, _expression, _pattern) do
-    false
-  end
-
   def has_pattern(ctx, expression, pattern) do
     [expression, pattern] = eval_args!([expression, pattern], ctx)
 
-    with {:ok, regex} <- Regex.compile(String.trim(pattern), "i"),
+    with false <- is_nil(expression),
+         {:ok, regex} <- Regex.compile(String.trim(pattern), "i"),
          [[_first | _remainder]] <- Regex.scan(regex, String.trim(expression), capture: :all) do
       # Future match result: first
       true

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1488,6 +1488,11 @@ defmodule Expression.Callbacks.Standard do
   """
   @expression_doc expression: "has_pattern(\"Buy cheese please\", \"buy (\\w+)\")", result: true
   @expression_doc expression: "has_pattern(\"Sell cheese please\", \"buy (\\w+)\")", result: false
+  @expression_doc expression: "has_pattern(nil, \"buy (\\w+)\")", result: false
+  def has_pattern(nil, _expression, _pattern) do
+    false
+  end
+
   def has_pattern(ctx, expression, pattern) do
     [expression, pattern] = eval_args!([expression, pattern], ctx)
 

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -34,6 +34,21 @@ defmodule ExpressionTest do
                Expression.evaluate_as_boolean!("@has_beginning(contact.number, \"123\")", %{
                  "contact" => %{"number" => 123_456}
                })
+
+      assert true ==
+               Expression.evaluate_as_boolean!(
+                 "@has_pattern(\"Buy cheese please\", \"buy (\\w+)\")",
+                 %{}
+               )
+
+      assert false ==
+               Expression.evaluate_as_boolean!(
+                 "@has_pattern(\"Sell cheese please\", \"buy (\\w+)\")",
+                 %{}
+               )
+
+      assert false ==
+               Expression.evaluate_as_boolean!("@has_pattern(nil, \"buy (\\w+)\")", %{})
     end
 
     test "evaluate_as_boolean! with kernel operators" do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -37,18 +37,18 @@ defmodule ExpressionTest do
 
       assert true ==
                Expression.evaluate_as_boolean!(
-                 "@has_pattern(\"Buy cheese please\", \"buy (\\w+)\")",
+                 "@has_pattern('Buy cheese please', 'buy (\\w+)')",
                  %{}
                )
 
       assert false ==
                Expression.evaluate_as_boolean!(
-                 "@has_pattern(\"Sell cheese please\", \"buy (\\w+)\")",
+                 "@has_pattern('Sell cheese please', 'buy (\\w+)')",
                  %{}
                )
 
       assert false ==
-               Expression.evaluate_as_boolean!("@has_pattern(nil, \"buy (\\w+)\")", %{})
+               Expression.evaluate_as_boolean!("@has_pattern(nil, 'buy (\\w+)')", %{})
     end
 
     test "evaluate_as_boolean! with kernel operators" do


### PR DESCRIPTION
`Expression.Callbacks.Standard.has_patter/3` fails when the `expression` arg value is `nil`, such as:

```
iex> Expression.evaluate_block!("has_pattern(nil, \"buy (\\w+)\")", %{}, Expression.Callbacks.Standard)
** (FunctionClauseError) no function clause matching in String.trim/1
```

This PR handles with `nil` expression values returning `false` for such cases.