### PR TITLE
Fix: handle nil expression in `evaluate_as_string`

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,7 +2,7 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created]
-  pull_request_target:
+  pull_request:
     types: [opened, closed, synchronize]
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -121,14 +121,16 @@ defmodule Expression do
 
   def evaluate_as_string!(expression, context \\ %{}, mod \\ Expression.Callbacks) do
     case expression do
-      nil -> ""
+      nil ->
+        ""
+
       _ ->
         expression
         |> parse!
         |> Eval.eval!(Context.new(context), mod)
         |> Eval.default_value(handle_not_found: true)
         |> stringify()
-      end
+    end
   end
 
   def evaluate_as_boolean!(expression, context \\ %{}, mod \\ Expression.Callbacks) do

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -119,18 +119,16 @@ defmodule Expression do
     |> Eval.default_value()
   end
 
-  def evaluate_as_string!(expression, context \\ %{}, mod \\ Expression.Callbacks) do
-    case expression do
-      nil ->
-        ""
+  def evaluate_as_string!(expression, context \\ %{}, mod \\ Expression.Callbacks)
 
-      _ ->
-        expression
-        |> parse!
-        |> Eval.eval!(Context.new(context), mod)
-        |> Eval.default_value(handle_not_found: true)
-        |> stringify()
-    end
+  def evaluate_as_string!(nil, _context, _mod), do: ""
+
+  def evaluate_as_string!(expression, context, mod) do
+    expression
+    |> parse!
+    |> Eval.eval!(Context.new(context), mod)
+    |> Eval.default_value(handle_not_found: true)
+    |> stringify()
   end
 
   def evaluate_as_boolean!(expression, context \\ %{}, mod \\ Expression.Callbacks) do

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -120,11 +120,15 @@ defmodule Expression do
   end
 
   def evaluate_as_string!(expression, context \\ %{}, mod \\ Expression.Callbacks) do
-    expression
-    |> parse!
-    |> Eval.eval!(Context.new(context), mod)
-    |> Eval.default_value(handle_not_found: true)
-    |> stringify()
+    case expression do
+      nil -> ""
+      _ ->
+        expression
+        |> parse!
+        |> Eval.eval!(Context.new(context), mod)
+        |> Eval.default_value(handle_not_found: true)
+        |> stringify()
+      end
   end
 
   def evaluate_as_boolean!(expression, context \\ %{}, mod \\ Expression.Callbacks) do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -170,6 +170,7 @@ defmodule ExpressionTest do
       assert "123" == Expression.evaluate_as_string!("@([1,2,3])")
       assert "1" == Expression.evaluate_as_string!(1)
       assert "1.5" == Expression.evaluate_as_string!(1.5)
+      assert "" == Expression.evaluate_as_string!(nil)
     end
 
     test "list with attribute" do


### PR DESCRIPTION
`evaluate_as_string/3` method fails when `expression` is `nil`. There are cases when `expression` is sent as `nil` since this method is called from `flow_runner` and various methods on `engage` backend where this case happens.

This PR handles the `nil` case in this method and adds the required test.