### PR TITLE
Fix/Add spec to `evaluate_as_string`

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         elixir: ["1.15"]
         otp: ["26"]
-        cache_version: ["1"]
+        cache_version: ["2"]
 
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       - name: Credo
         run: mix credo --strict
       - name: Retrieve PLT Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: plt-cache
         with:
           path: .plts

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -119,6 +119,11 @@ defmodule Expression do
     |> Eval.default_value()
   end
 
+  @spec evaluate_as_string!(
+          String.t() | nil,
+          map(),
+          module()
+        ) :: String.t()
   def evaluate_as_string!(expression, context \\ %{}, mod \\ Expression.Callbacks)
 
   def evaluate_as_string!(nil, _context, _mod), do: ""


### PR DESCRIPTION
The current dialyzer in our main repo is failing after the latest release. Perhaps adding the spec will help fix the issue since the method has multiple clauses now.