### PR TITLE
Fix `evaluate_as_string` spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 2.41.3"}
+    {:expression, "~> 2.41.4"}
   ]
 end
 ```

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -120,7 +120,7 @@ defmodule Expression do
   end
 
   @spec evaluate_as_string!(
-          String.t() | nil,
+          any(),
           map(),
           module()
         ) :: String.t()

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -120,7 +120,7 @@ defmodule Expression do
   end
 
   @spec evaluate_as_string!(
-          any(),
+          String.t() | Number.t() | nil,
           map(),
           module()
         ) :: String.t()

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "2.41.3"
+  @version "2.41.4"
 
   def project do
     [


### PR DESCRIPTION
Adding `Number.t()` to the expression types for `evaluate_as_string` spec. The reason for this is a failure in the main repo when the spec for `evaluate_as_string` was added. Also the `parser` allows string and number types ` @spec parse!(String.t() | Number.t()) :: Keyword.t() `

Adding a release `2.41.4`