### PR TITLE
Handle dates starting with 0

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,14 +15,14 @@ jobs:
         cache_version: ["2"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Restore dependencies cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: mix-cache
         with:
           path: deps
@@ -39,7 +39,7 @@ jobs:
       - name: Credo
         run: mix credo --strict
       - name: Retrieve PLT Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: plt-cache
         with:
           path: .plts

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.16.0-otp-26
-erlang 26.2.1
+elixir 1.18.1-otp-27
+erlang 27.0

--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -54,7 +54,8 @@ defmodule Expression.Context do
 
   defp iterate({key, value}, opts) when is_binary(value) do
     cond do
-      # Prevent implicitly converting numbers starting with a zero - only allows strings fully made of digits or decimals
+      # Prevent implicitly converting numbers starting with a zero
+      # Only allows strings fully made of digits or decimals
       String.starts_with?(value, "0") and String.match?(value, ~r/^\d+(\.\d+)?$/) -> {key, value}
       Keyword.get(opts, :skip_context_evaluation?, false) -> {key, value}
       true -> {key, evaluate!(value, opts)}

--- a/lib/expression/context.ex
+++ b/lib/expression/context.ex
@@ -52,20 +52,12 @@ defmodule Expression.Context do
   # Implictly convert the string "0" as a number
   defp iterate({key, "0"}, _opts), do: {key, 0}
 
-  # Prevent implictly converting numbers starting with a zero
-  defp iterate({key, "0" <> value}, opts) when is_binary(value) do
-    if String.match?("0" <> value, ~r/^[0-9]/) do
-      {key, "0" <> value}
-    else
-      iterate({key, value}, opts)
-    end
-  end
-
   defp iterate({key, value}, opts) when is_binary(value) do
-    if Keyword.get(opts, :skip_context_evaluation?, false) do
-      {key, value}
-    else
-      {key, evaluate!(value, opts)}
+    cond do
+      # Prevent implicitly converting numbers starting with a zero - only allows strings fully made of digits or decimals
+      String.starts_with?(value, "0") and String.match?(value, ~r/^\d+(\.\d+)?$/) -> {key, value}
+      Keyword.get(opts, :skip_context_evaluation?, false) -> {key, value}
+      true -> {key, evaluate!(value, opts)}
     end
   end
 

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -200,7 +200,6 @@ defmodule Expression.Eval do
   def op(:=, a, b) when is_struct(a, Date) and is_struct(b, Date),
     do: Date.compare(a, b) == :eq
 
-  # Support comparing a `Date`/`DateTime` value with an ISO8601 date/datetime string
   def op(operator, a, b) when operator in [:=, :==] and is_nil(a) and is_nil(b) do
     true
   end
@@ -210,6 +209,7 @@ defmodule Expression.Eval do
     false
   end
 
+  # Support comparing a `Date`/`DateTime` value with an ISO8601 date/datetime string
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def op(operator, a, b)
       when operator in [:=, :==, :!=, :<, :<=, :>, :>=] and

--- a/test/expression/context_test.exs
+++ b/test/expression/context_test.exs
@@ -2,6 +2,34 @@ defmodule Expression.ContextTest do
   use ExUnit.Case
   alias Expression.Context
 
+  test "new context from a context containing a date string in dd/mm/yyyy" do
+    context = %{"block" => %{"value" => %{"birth_date" => "19/10/2002"}}}
+
+    assert %{"block" => %{"value" => %{"birth_date" => ~D[2002-10-19]}}} =
+             Context.new(context)
+  end
+
+  test "new context from a context containing a date string in dd/mm/yyyy starting with 0" do
+    context = %{"block" => %{"value" => %{"birth_date" => "09/10/2002"}}}
+
+    assert %{"block" => %{"value" => %{"birth_date" => ~D[2002-10-09]}}} =
+             Context.new(context)
+  end
+
+  test "new context from a context containing a date string in dd-mm-yyyy" do
+    context = %{"block" => %{"value" => %{"birth_date" => "19-10-2002"}}}
+
+    assert %{"block" => %{"value" => %{"birth_date" => ~D[2002-10-19]}}} =
+             Context.new(context)
+  end
+
+  test "new context from a context containing a date string in dd-mm-yyyy starting with 0" do
+    context = %{"block" => %{"value" => %{"birth_date" => "09-10-2002"}}}
+
+    assert %{"block" => %{"value" => %{"birth_date" => ~D[2002-10-09]}}} =
+             Context.new(context)
+  end
+
   test "new context from a context containing a datetime string" do
     context = %{"block" => %{"value" => %{"program_start_date" => "2022-11-10T13:40:05.921378"}}}
 


### PR DESCRIPTION
Discovered during the debugging of this ticket: https://linear.app/turnio/issue/PROD-1422/junior-achievement-mexico-journey-is-not-saving-user-data-to-the#comment-ac7c10ab
that dates starting with 0 become victims of this and we lose them resulting in not accepting birthdates.

Comment with context for this issue: https://linear.app/turnio/issue/PROD-1422/junior-achievement-mexico-journey-is-not-saving-user-data-to-the#comment-572d8508

Old tests still pass with these changes.