### PR TITLE
Fix: handle nil values on date.compare/2 on eval

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -203,6 +203,11 @@ defmodule Expression.Eval do
   # Support comparing a `Date`/`DateTime` value with an ISO8601 date/datetime string
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def op(operator, a, b)
+      when operator in [:=, :==, :!=, :<, :<=, :>, :>=] and (is_nil(a) or is_nil(b)) do
+    false
+  end
+
+  def op(operator, a, b)
       when operator in [:=, :==, :!=, :<, :<=, :>, :>=] and
              (((is_struct(a, Date) or is_struct(a, DateTime)) and is_binary(b)) or
                 (is_binary(a) and (is_struct(b, Date) or is_struct(b, DateTime)))) do
@@ -215,15 +220,10 @@ defmodule Expression.Eval do
       end
 
     comparison_result =
-      cond do
-        is_nil(date_a) or is_nil(date_b) ->
-          nil
-
-        is_struct(date_a, Date) ->
-          Date.compare(date_a, date_b)
-
-        true ->
-          DateTime.compare(date_a, date_b)
+      if is_struct(date_a, Date) do
+        Date.compare(date_a, date_b)
+      else
+        DateTime.compare(date_a, date_b)
       end
 
     case {operator, comparison_result} do

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -215,10 +215,15 @@ defmodule Expression.Eval do
       end
 
     comparison_result =
-      if is_struct(date_a, Date) do
-        Date.compare(date_a, date_b)
-      else
-        DateTime.compare(date_a, date_b)
+      cond do
+        is_struct(date_a, Date) and is_nil(date_b) ->
+          nil
+
+        is_struct(date_a, Date) ->
+          Date.compare(date_a, date_b)
+
+        true ->
+          DateTime.compare(date_a, date_b)
       end
 
     case {operator, comparison_result} do

--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -216,7 +216,7 @@ defmodule Expression.Eval do
 
     comparison_result =
       cond do
-        is_struct(date_a, Date) and is_nil(date_b) ->
+        is_nil(date_a) or is_nil(date_b) ->
           nil
 
         is_struct(date_a, Date) ->

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -399,4 +399,52 @@ defmodule Expression.EvalTest do
       assert true == Eval.eval!(ast, %{"a" => ~U[2023-11-16 10:40:50.277482Z]})
     end
   end
+
+  describe "handling nil values in date/datetime comparisons" do
+    test "op function directly handles nil in date/datetime comparisons" do
+      # Direct tests of the op function for nil handling
+      date = ~D[2024-01-01]
+      datetime = ~U[2024-01-01 10:40:50.277482Z]
+      date_str = "2024-01-01"
+      datetime_str = "2024-01-01T10:40:50.277482Z"
+
+      # Date with nil string tests
+      assert false == Expression.Eval.op(:>, date, nil)
+      assert false == Expression.Eval.op(:<, date, nil)
+      assert false == Expression.Eval.op(:==, date, nil)
+      assert false == Expression.Eval.op(:>=, date, nil)
+      assert false == Expression.Eval.op(:<=, date, nil)
+
+      # nil with Date string tests
+      assert false == Expression.Eval.op(:>, nil, date)
+      assert false == Expression.Eval.op(:<, nil, date)
+      assert false == Expression.Eval.op(:==, nil, date)
+      assert false == Expression.Eval.op(:>=, nil, date)
+      assert false == Expression.Eval.op(:<=, nil, date)
+
+      # DateTime with nil tests
+      assert false == Expression.Eval.op(:>, datetime, nil)
+      assert false == Expression.Eval.op(:<, datetime, nil)
+      assert false == Expression.Eval.op(:==, datetime, nil)
+      assert false == Expression.Eval.op(:>=, datetime, nil)
+      assert false == Expression.Eval.op(:<=, datetime, nil)
+
+      # nil with DateTime tests
+      assert false == Expression.Eval.op(:>, nil, datetime)
+      assert false == Expression.Eval.op(:<, nil, datetime)
+      assert false == Expression.Eval.op(:==, nil, datetime)
+      assert false == Expression.Eval.op(:>=, nil, datetime)
+      assert false == Expression.Eval.op(:<=, nil, datetime)
+
+      # Date string with nil
+      assert false == Expression.Eval.op(:>, date_str, nil)
+      assert false == Expression.Eval.op(:<, date_str, nil)
+      assert false == Expression.Eval.op(:==, date_str, nil)
+
+      # DateTime string with nil
+      assert false == Expression.Eval.op(:>, datetime_str, nil)
+      assert false == Expression.Eval.op(:<, datetime_str, nil)
+      assert false == Expression.Eval.op(:==, datetime_str, nil)
+    end
+  end
 end

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -445,6 +445,13 @@ defmodule Expression.EvalTest do
       assert false == Expression.Eval.op(:>, datetime_str, nil)
       assert false == Expression.Eval.op(:<, datetime_str, nil)
       assert false == Expression.Eval.op(:==, datetime_str, nil)
+
+      # Comparing nil with nil values
+      assert false == Expression.Eval.op(:>, nil, nil)
+      assert false == Expression.Eval.op(:<, nil, nil)
+      assert false == Expression.Eval.op(:==, nil, nil)
+      assert false == Expression.Eval.op(:>=, nil, nil)
+      assert false == Expression.Eval.op(:<=, nil, nil)
     end
   end
 end


### PR DESCRIPTION
`Date.compare/2` fails when one of the date is `nil`.

