### PR TITLE
Handle nil values on Date.compare/2

### DIFF
--- a/lib/expression/eval.ex
+++ b/lib/expression/eval.ex
@@ -224,10 +224,15 @@ defmodule Expression.Eval do
       end
 
     comparison_result =
-      if is_struct(date_a, Date) do
-        Date.compare(date_a, date_b)
-      else
-        DateTime.compare(date_a, date_b)
+      cond do
+        is_nil(date_a) or is_nil(date_b) ->
+          nil
+
+        is_struct(date_a, Date) ->
+          Date.compare(date_a, date_b)
+
+        true ->
+          DateTime.compare(date_a, date_b)
       end
 
     case {operator, comparison_result} do

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -454,5 +454,39 @@ defmodule Expression.EvalTest do
       assert false == Expression.Eval.op(:>=, nil, nil)
       assert false == Expression.Eval.op(:<=, nil, nil)
     end
+
+    test "op function directly handles binary in date/datetime comparisons" do
+      # Direct tests of the op function for binary handling
+      date = ~D[2024-01-01]
+      datetime = ~U[2024-01-01 10:40:50.277482Z]
+
+      # Date with binary string tests
+      assert false == Expression.Eval.op(:>, date, "binary")
+      assert false == Expression.Eval.op(:<, date, "binary")
+      assert false == Expression.Eval.op(:==, date, "binary")
+      assert false == Expression.Eval.op(:>=, date, "binary")
+      assert false == Expression.Eval.op(:<=, date, "binary")
+
+      # "binary" with Date string tests
+      assert false == Expression.Eval.op(:>, "binary", date)
+      assert false == Expression.Eval.op(:<, "binary", date)
+      assert false == Expression.Eval.op(:==, "binary", date)
+      assert false == Expression.Eval.op(:>=, "binary", date)
+      assert false == Expression.Eval.op(:<=, "binary", date)
+
+      # DateTime with "binary" tests
+      assert false == Expression.Eval.op(:>, datetime, "binary")
+      assert false == Expression.Eval.op(:<, datetime, "binary")
+      assert false == Expression.Eval.op(:==, datetime, "binary")
+      assert false == Expression.Eval.op(:>=, datetime, "binary")
+      assert false == Expression.Eval.op(:<=, datetime, "binary")
+
+      # "binary" with DateTime tests
+      assert false == Expression.Eval.op(:>, "binary", datetime)
+      assert false == Expression.Eval.op(:<, "binary", datetime)
+      assert false == Expression.Eval.op(:==, "binary", datetime)
+      assert false == Expression.Eval.op(:>=, "binary", datetime)
+      assert false == Expression.Eval.op(:<=, "binary", datetime)
+    end
   end
 end


### PR DESCRIPTION
Date.compare/2 fails when one of the argument is nil.