### PR TITLE
Add support for complex values in if statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 2.44.0"}
+    {:expression, "~> 2.45.1"}
   ]
 end
 ```

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -597,10 +597,14 @@ defmodule Expression.Callbacks.Standard do
                   code_expression: "# Shorthand\nif(false, do: \"Yes\", else: \"No\")",
                   result: "No"
   def if_(ctx, condition, yes, no) do
-    if(eval!(condition, ctx),
-      do: eval!(yes, ctx),
-      else: eval!(no, ctx)
-    )
+    result =
+      case eval!(condition, ctx) do
+        # Handle complex objects
+        %{"__value__" => value} -> value
+        other -> other
+      end
+
+    if result, do: eval!(yes, ctx), else: eval!(no, ctx)
   end
 
   @doc """

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -599,7 +599,7 @@ defmodule Expression.Callbacks.Standard do
   def if_(ctx, condition, yes, no) do
     result =
       case eval!(condition, ctx) do
-        # Handle complex objects
+        # Handle complex values
         %{"__value__" => value} -> value
         other -> other
       end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "2.45.0"
+  @version "2.45.1"
 
   def project do
     [

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -114,8 +114,8 @@ defmodule Expression.EvalTest do
     {:ok, ast, "", _, _, _} = Parser.parse("@if(result == 1,\nresult.message,\nfalse)")
 
     assert Eval.eval!(ast, %{
-             "result" => %{"__value__" => 1, "error" => false, "message" => "some reason"}
-           }) == "some reason"
+             "result" => %{"__value__" => 1, "error" => false, "message" => "some message"}
+           }) == "some message"
   end
 
   describe "lambdas" do

--- a/test/expression/eval_test.exs
+++ b/test/expression/eval_test.exs
@@ -107,10 +107,15 @@ defmodule Expression.EvalTest do
     {:ok, ast, "", _, _, _} =
       Parser.parse("@if(image_response.status == 200,\nimage_response.body.id,\nfalse)")
 
-    assert false ==
-             Eval.eval!(ast, %{
-               "image_response" => %{"status" => 500, "body" => "Internal Server Error"}
-             })
+    assert Eval.eval!(ast, %{
+             "image_response" => %{"status" => 500, "body" => "Internal Server Error"}
+           }) == false
+
+    {:ok, ast, "", _, _, _} = Parser.parse("@if(result == 1,\nresult.message,\nfalse)")
+
+    assert Eval.eval!(ast, %{
+             "result" => %{"__value__" => 1, "error" => false, "message" => "some reason"}
+           }) == "some reason"
   end
 
   describe "lambdas" do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -483,6 +483,36 @@ defmodule ExpressionTest do
                })
     end
 
+    test "checking for complex objects with if" do
+      assert Expression.evaluate!("@IF(var, var, 0)", %{
+               "var" => %{
+                 "__value__" => 1,
+                 "error" => false,
+                 "message" => "some reason"
+               }
+             }) == 1
+
+      assert Expression.evaluate!("@IF(var, var, 0)", %{
+               "var" => %{
+                 "__value__" => nil,
+                 "error" => true,
+                 "message" => "some reason"
+               }
+             }) == 0
+
+      assert Expression.evaluate!("@IF(var, var, 0)", %{}) == 0
+
+      assert Expression.evaluate!("@IF(var.foo, var.foo, 0)", %{
+               "var" => %{
+                 "foo" => %{
+                   "__value__" => 1,
+                   "error" => false,
+                   "message" => "some reason"
+                 }
+               }
+             }) == 1
+    end
+
     test "function calls with expressions" do
       assert {:ok, ["Dear ", "lovely client"]} =
                Expression.evaluate("Dear @IF(contact.gender = 'M', 'Sir', 'lovely client')", %{

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -483,12 +483,12 @@ defmodule ExpressionTest do
                })
     end
 
-    test "checking for complex objects with if" do
+    test "checking for complex values with if" do
       assert Expression.evaluate!("@IF(var, var, 0)", %{
                "var" => %{
                  "__value__" => 1,
                  "error" => false,
-                 "message" => "some reason"
+                 "message" => "some message"
                }
              }) == 1
 
@@ -496,7 +496,7 @@ defmodule ExpressionTest do
                "var" => %{
                  "__value__" => nil,
                  "error" => true,
-                 "message" => "some reason"
+                 "message" => "some message"
                }
              }) == 0
 
@@ -507,7 +507,7 @@ defmodule ExpressionTest do
                  "foo" => %{
                    "__value__" => 1,
                    "error" => false,
-                   "message" => "some reason"
+                   "message" => "some message"
                  }
                }
              }) == 1


### PR DESCRIPTION
Add support for complex values with a `__value__` attribute in `if/3` expression callback.

Right now, it's failing because it does not support complex values returned by other expressions:
![image](https://github.com/user-attachments/assets/b3de5e83-7d4b-4b02-bee8-21fd649dbaef)
