### PR TITLE
[PROD-2052] Convert back Time type values to string on `parse!`

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -98,7 +98,7 @@ defmodule Expression do
     end
   end
 
-  @spec time_struct?(String.t() | Number.t() | Time.t()) :: boolean
+  @spec time_struct?(String.t() | Time.t()) :: boolean
   def time_struct?(value), do: is_struct(value, Time)
 
   def evaluate_block!(

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -87,7 +87,7 @@ defmodule Expression do
   def parse!(expression) when is_number(expression), do: to_string(expression) |> parse!()
 
   def parse!(expression) do
-    expression = if is_time?(expression), do: Time.to_string(expression), else: expression
+    expression = if time_struct?(expression), do: Time.to_string(expression), else: expression
 
     case Parser.parse(expression) do
       {:ok, ast, "", _, _, _} ->
@@ -98,8 +98,8 @@ defmodule Expression do
     end
   end
 
-  @spec is_time?(String.t() | Number.t() | Time.t()) :: boolean
-  def is_time?(value), do: is_struct(value, Time)
+  @spec time_struct?(String.t() | Number.t() | Time.t()) :: boolean
+  def time_struct?(value), do: is_struct(value, Time)
 
   def evaluate_block!(
         expression,

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -83,10 +83,12 @@ defmodule Expression do
     String.replace(expression, ~r/@([a-z]+)(\(|\.)?/i, "@@\\g{1}\\g{2}")
   end
 
-  @spec parse!(String.t() | Number.t()) :: Keyword.t()
+  @spec parse!(String.t() | Number.t() | Time.t()) :: Keyword.t()
   def parse!(expression) when is_number(expression), do: to_string(expression) |> parse!()
 
   def parse!(expression) do
+    expression = if is_time?(expression), do: Time.to_string(expression), else: expression
+
     case Parser.parse(expression) do
       {:ok, ast, "", _, _, _} ->
         ast
@@ -95,6 +97,9 @@ defmodule Expression do
         raise "Unable to parse expression: #{expression}, remainder: #{inspect(remainder)}"
     end
   end
+
+  @spec is_time?(String.t() | Number.t() | Time.t()) :: boolean
+  def is_time?(value), do: is_struct(value, Time)
 
   def evaluate_block!(
         expression,

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -178,6 +178,11 @@ defmodule ExpressionTest do
                Expression.evaluate_as_string!("@foo[0].name", %{"foo" => [%{"name" => "bar"}]})
     end
 
+    test "Stringify time sigil" do
+      assert "11:00:00" =
+               Expression.evaluate_as_string!(~T[11:00:00])
+    end
+
     test "list with out of bound indicess" do
       assert nil ==
                Expression.evaluate!("@foo[cursor]", %{"foo" => ["baz", "bar"], "cursor" => 100})


### PR DESCRIPTION
Time inputs are automatically converted to Time structs. This PR converts such values back to strings on the function `parse!`.