### PR TITLE
[docs] remove duplicate category for fixed/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 2.47.0"}
+    {:expression, "~> 2.47.1"}
   ]
 end
 ```

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -855,7 +855,6 @@ defmodule Expression.Callbacks.Standard do
   @expression_doc expression: "fixed(3.7979, 2, false)", result: "3.80"
   @expression_doc expression: "fixed(3.7979, 2)", result: "3.80"
   @expression_doc expression: "fixed(0.0909, 2)", result: "0.09"
-  @expression_category "string"
   def fixed(ctx, number, precision) do
     [number, precision] = eval_args!([number, precision], ctx)
     Number.Delimit.number_to_delimited(number, precision: precision)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "2.47.0"
+  @version "2.47.1"
 
   def project do
     [


### PR DESCRIPTION
`fixed` was wrongly categorised twice. Removing the `string` category and bumping the patch version.