### PR TITLE
[docs] remove duplicate category for fixed/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 2.47.1"}
+    {:expression, "~> 2.47.2"}
   ]
 end
 ```

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -860,7 +860,7 @@ defmodule Expression.Callbacks.Standard do
     Number.Delimit.number_to_delimited(number, precision: precision)
   end
 
-  @expression_category "string"
+  @expression_category "number"
   def fixed(ctx, number, precision, no_commas) do
     case eval_args!([number, precision, no_commas], ctx) do
       [number, precision, true] ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "2.47.1"
+  @version "2.47.2"
 
   def project do
     [


### PR DESCRIPTION
Follow up on https://github.com/turnhub/expression/pull/279. `fixed/3` was wrongly categorised as string. Changing the string category and bumping the patch version.