### PR TITLE
version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 2.47.2"}
+    {:expression, "~> 2.47.3"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "2.47.2"
+  @version "2.47.3"
 
   def project do
     [


### PR DESCRIPTION
This pull request updates the `expression` dependency to the latest patch version. The changes are minor and ensure that the project uses version `2.47.3` instead of `2.47.2`.

* Updated the version of `expression` in both `mix.exs` and the installation instructions in `README.md` to `2.47.3`. [[1]](diffhunk://#diff-dfa6f4ed74c90e5d4fda283d547d366586e690387289bcfd473e3fa5f9ace308L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R142)