### PR TITLE
Test against new versions of Elixir/OTP that we're using on engage

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,10 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ["1.15", "1.18"]
-        otp: ["26", "27"]
+        elixir: ["1.15", "1.18", "1.19"]
+        otp: ["26", "27", "28"]
         exclude:
           - elixir: "1.15"
+            otp: "27"
+          - elixir: "1.15"
+            otp: "28"
+          - elixir: "1.18"
+            otp: "28"
+          - elixir: "1.19"
+            otp: "26"
+          - elixir: "1.19"
             otp: "27"
         cache_version: ["3"]
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,19 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ["1.15", "1.18", "1.19"]
-        otp: ["26", "27", "28"]
-        exclude:
+        include:
           - elixir: "1.15"
-            otp: "27"
-          - elixir: "1.15"
-            otp: "28"
-          - elixir: "1.18"
-            otp: "28"
-          - elixir: "1.19"
             otp: "26"
-          - elixir: "1.19"
+          - elixir: "1.18"
             otp: "27"
+          - elixir: "1.19"
+            otp: "28"
         cache_version: ["3"]
 
     steps:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,10 +16,13 @@ jobs:
         include:
           - elixir: "1.15"
             otp: "26"
+            check_formatting: false
           - elixir: "1.18"
             otp: "27"
+            check_formatting: false
           - elixir: "1.19"
             otp: "28"
+            check_formatting: true
         cache_version: ["3"]
 
     steps:
@@ -43,6 +46,7 @@ jobs:
           mix local.hex --force
           mix deps.get
       - name: Check Formatting
+        if: matrix.check_formatting
         run: mix format --check-formatted
       - name: Credo
         run: mix credo --strict

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.16"
-          otp-version: "26"
+          elixir-version: "1.19"
+          otp-version: "28"
       - name: Publish to Hex.pm
         run: |
           mix local.hex --force

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.1-otp-27
-erlang 27.0
+elixir 1.19.4-otp-28
+erlang 28.1

--- a/README.md
+++ b/README.md
@@ -156,3 +156,7 @@ version.
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/expression](https://hexdocs.pm/expression).
+
+## Testing & Compatibility
+
+We follow a diagonal testing strategy to ensure backward compatibility while keeping CI manageable. If you encounter issues with a specific version combination within our supported range, please open an issue.

--- a/test/expression/v2/parser_test.exs
+++ b/test/expression/v2/parser_test.exs
@@ -217,8 +217,8 @@ defmodule Expression.V2.ParserTest do
                 "\nHi there ",
                 [{"__property__", ["contact", "whatsapp_profile_name"]}],
                 "\n\n*HANGMAN*)\n)\n"
-              ], "", _, _,
-              _} = Parser.parse("\nHi there @contact.whatsapp_profile_name\n\n*HANGMAN*)\n)\n")
+              ], "", _, _, _} =
+               Parser.parse("\nHi there @contact.whatsapp_profile_name\n\n*HANGMAN*)\n)\n")
     end
   end
 end

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -601,7 +601,7 @@ defmodule ExpressionTest do
                      })
                    end
 
-      assert_raise BadMapError, "expected a map, got: [\"A\", \"B\", \"C\"]", fn ->
+      assert_raise BadMapError, ~r/expected a map, got:.*\["A", "B", "C"\]/s, fn ->
         Expression.evaluate("@delete(map, \"key\")", %{
           "map" => ["A", "B", "C"]
         })


### PR DESCRIPTION
@smn @santiagocardo @fedme Hoping to clarify something with this PR:

What versions of Elixir+OTP are we committing to supporting, given that this is a public repo, with dependents outside of Turn.io?

Should we just have a min and max version of elxiir and OTP?

I've taken a stab at how we might do this, but the number of runs will grow exponentially with this matrix approach.