### PR TITLE
Add boolean type support to parse! function

### DIFF
--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -83,8 +83,9 @@ defmodule Expression do
     String.replace(expression, ~r/@([a-z]+)(\(|\.)?/i, "@@\\g{1}\\g{2}")
   end
 
-  @spec parse!(String.t() | Number.t() | Time.t()) :: Keyword.t()
+  @spec parse!(String.t() | Number.t() | Time.t() | boolean()) :: Keyword.t()
   def parse!(expression) when is_number(expression), do: to_string(expression) |> parse!()
+  def parse!(expression) when is_boolean(expression), do: to_string(expression) |> parse!()
 
   def parse!(expression) do
     expression = if time_struct?(expression), do: Time.to_string(expression), else: expression

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -170,6 +170,8 @@ defmodule ExpressionTest do
       assert "123" == Expression.evaluate_as_string!("@([1,2,3])")
       assert "1" == Expression.evaluate_as_string!(1)
       assert "1.5" == Expression.evaluate_as_string!(1.5)
+      assert "true" == Expression.evaluate_as_string!(true)
+      assert "false" == Expression.evaluate_as_string!(false)
       assert "" == Expression.evaluate_as_string!(nil)
     end
 
@@ -582,6 +584,27 @@ defmodule ExpressionTest do
     assert "@@bar[0]" == Expression.escape("@bar[0]")
     assert "@@if(foo, bar, baz)" == Expression.escape("@if(foo, bar, baz)")
     assert "@@if(foo, bar.baz, baz)" == Expression.escape("@if(foo, bar.baz, baz)")
+  end
+
+  describe "parse!/1" do
+    test "parses string expressions" do
+      assert [text: "hello"] = Expression.parse!("hello")
+      assert [expression: [atom: "foo"]] = Expression.parse!("@foo")
+    end
+
+    test "parses number primitives by converting to string" do
+      assert [text: "42"] = Expression.parse!(42)
+      assert [text: "3.14"] = Expression.parse!(3.14)
+    end
+
+    test "parses boolean primitives by converting to string" do
+      assert [text: "true"] = Expression.parse!(true)
+      assert [text: "false"] = Expression.parse!(false)
+    end
+
+    test "parses Time struct by converting to string" do
+      assert [text: "11:00:00"] = Expression.parse!(~T[11:00:00])
+    end
   end
 
   describe "context is parsed correctly when using the skip_context_evaluation? option" do


### PR DESCRIPTION
This PR fixes a `FunctionClauseError` that occurs when boolean values (`true` or `false`) are passed to `Expression.evaluate_as_string!/3`.

Currently, the `parse!/1` function handles several primitive types by converting them to strings before parsing:
- Numbers (integers and floats)
- Time structs
- Nil values

However, it lacks a clause for boolean values, causing crashes when booleans are passed directly to evaluation functions like `evaluate_as_string!`. This is inconsistent behavior, as booleans are a common primitive type that should be stringifiable just like numbers.