### PR TITLE
update release process for expressions lib to reduce manual steps

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -23,6 +23,7 @@ jobs:
           - elixir: "1.19"
             otp: "28"
             check_formatting: true
+        # when updating this, please also see ./releases.yml
         cache_version: ["3"]
 
     steps:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -3,9 +3,15 @@ name: Elixir CI
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - "*.md"
+      - ".github/workflows/releases.yml"
   push:
     branches:
       - develop
+    paths-ignore:
+      - "*.md"
+      - ".github/workflows/releases.yml"
 
 jobs:
   build:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,26 +1,97 @@
 name: Hex.pm releases
 
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [published]
+
+env:
+  ELIXIR_VERSION: "1.19"
+  OTP_VERSION: "28"
+  # when updating this, please also see ./elixir.yml
+  CACHE_VERSION: "3"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.19"
-          otp-version: "28"
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        id: mix-cache
+        with:
+          path: deps
+          key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-mix-
+
+      - name: Install Mix Dependencies
+        if: steps.mix-cache.outputs.cache-hit != 'true'
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+
+      - name: Verify and update version
+        run: |
+          # Extract version from release tag (removes 'v' prefix if present)
+          RELEASE_VERSION="${{ github.event.release.tag_name }}"
+          RELEASE_VERSION="${RELEASE_VERSION#v}"
+          echo "Release version: $RELEASE_VERSION"
+
+          # Extract current version from mix.exs
+          MIX_VERSION=$(grep -oP '@version "\K[^"]+' mix.exs)
+          echo "mix.exs version: $MIX_VERSION"
+
+          # Extract current version from README.md
+          README_VERSION=$(grep -oP '\{:expression, "~> \K[^"]+' README.md)
+          echo "README.md version: $README_VERSION"
+
+          # Track if we need to commit changes
+          NEEDS_UPDATE=false
+
+          # Update mix.exs if version doesn't match
+          if [ "$MIX_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Updating mix.exs version from $MIX_VERSION to $RELEASE_VERSION"
+            sed -i "s/@version \"$MIX_VERSION\"/@version \"$RELEASE_VERSION\"/" mix.exs
+            NEEDS_UPDATE=true
+          fi
+
+          # Update README.md if version doesn't match
+          if [ "$README_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Updating README.md version from $README_VERSION to $RELEASE_VERSION"
+            sed -i "s/{:expression, \"~> $README_VERSION\"}/{:expression, \"~> $RELEASE_VERSION\"}/" README.md
+            NEEDS_UPDATE=true
+          fi
+
+          # Commit and push if changes were made
+          if [ "$NEEDS_UPDATE" = true ]; then
+            echo "Committing version updates..."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add mix.exs README.md
+            git commit -m "Bump version to $RELEASE_VERSION [skip ci]"
+            git push origin HEAD:${{ github.event.release.target_commitish }}
+          else
+            echo "All versions already match $RELEASE_VERSION"
+          fi
+
       - name: Publish to Hex.pm
         run: |
           mix local.hex --force
           mix local.rebar --force
-          mix hex.organization auth turnio --key ${{secrets.HEX_ORG_KEY}}
+          mix hex.organization auth turnio --key ${{ secrets.HEX_ORG_KEY }}
           mix do deps.get, deps.compile
           mix compile
           mix hex.build

--- a/README.md
+++ b/README.md
@@ -146,10 +146,17 @@ end
 
 ## Doing releases
 
-Use the Github UI to create a new release and publish it. Make sure to update the
-`mix.exs` and `README.md` version references _before_ publishing otherwise hex.pm
-will complain and prevent you from publishing over an already existing released
-version.
+To publish a new release:
+
+1. Go to the [GitHub Releases page](https://github.com/turnhub/expression/releases)
+2. Click "Draft a new release"
+3. Create a new tag with the version number (e.g., `2.48.0` or `v2.48.0`)
+4. Fill in the release notes and publish
+
+The CI workflow will automatically:
+- Update the version in `mix.exs` and `README.md` if they don't match the release tag
+- Commit those changes back to the repository
+- Publish the package to Hex.pm
 
 ## Documentation
 


### PR DESCRIPTION
This updates `.github/workflows/releases.yml` to do a few things.

1. only trigger when a Release is created.
```
on:
  release:
    types: [published]
```
2. have the script itself verify the version listed in `mix.exs` and `README.md` and if the version tag doesn't match, update it appropriately with version control, _before_ releasing to hex and hexdocs. (I've had some success with this approach, [in a personal project ](https://github.com/nathanbegbie/cooklang_ex/blob/main/.github/workflows/release.yml)
3. Add dependency caching, like we do in the `elixir.yml` workflow
4. Update the README.md to reflect this process

## BUT WHY?

Anything that we can do to simplify the release process, the better. This enables the support team to be able to rapidly create releases as needed, without needing to faff about with updating versions appropriately _before_ creating a release. This can just be fire and forget.

## Side Quests

Update the workflows so that they only trigger on appropriate file changes
