### PR TITLE
Change release workflow to verify versions instead of auto-updating

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -14,13 +14,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Check out
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.target_commitish }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup BEAM
         uses: erlef/setup-beam@v1
@@ -43,7 +42,7 @@ jobs:
           mix local.hex --force
           mix deps.get
 
-      - name: Verify and update version
+      - name: Verify versions match release tag
         run: |
           # Extract version from release tag (removes 'v' prefix if present)
           RELEASE_VERSION="${{ github.event.release.tag_name }}"
@@ -58,34 +57,19 @@ jobs:
           README_VERSION=$(grep -oP '\{:expression, "~> \K[^"]+' README.md)
           echo "README.md version: $README_VERSION"
 
-          # Track if we need to commit changes
-          NEEDS_UPDATE=false
-
-          # Update mix.exs if version doesn't match
-          if [ "$MIX_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "Updating mix.exs version from $MIX_VERSION to $RELEASE_VERSION"
-            sed -i "s/@version \"$MIX_VERSION\"/@version \"$RELEASE_VERSION\"/" mix.exs
-            NEEDS_UPDATE=true
+          # Verify versions match
+          if [ "$MIX_VERSION" != "$RELEASE_VERSION" ] || [ "$README_VERSION" != "$RELEASE_VERSION" ]; then
+            echo ""
+            echo "ERROR: Version mismatch detected!"
+            echo "  Release tag: $RELEASE_VERSION"
+            echo "  mix.exs:     $MIX_VERSION"
+            echo "  README.md:   $README_VERSION"
+            echo ""
+            echo "Please update mix.exs and README.md to match the release version before publishing."
+            exit 1
           fi
 
-          # Update README.md if version doesn't match
-          if [ "$README_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "Updating README.md version from $README_VERSION to $RELEASE_VERSION"
-            sed -i "s/{:expression, \"~> $README_VERSION\"}/{:expression, \"~> $RELEASE_VERSION\"}/" README.md
-            NEEDS_UPDATE=true
-          fi
-
-          # Commit and push if changes were made
-          if [ "$NEEDS_UPDATE" = true ]; then
-            echo "Committing version updates..."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add mix.exs README.md
-            git commit -m "Bump version to $RELEASE_VERSION [skip ci]"
-            git push origin HEAD:${{ github.event.release.target_commitish }}
-          else
-            echo "All versions already match $RELEASE_VERSION"
-          fi
+          echo "All versions match $RELEASE_VERSION"
 
       - name: Publish to Hex.pm
         run: |

--- a/README.md
+++ b/README.md
@@ -148,15 +148,20 @@ end
 
 To publish a new release:
 
-1. Go to the [GitHub Releases page](https://github.com/turnhub/expression/releases)
-2. Click "Draft a new release"
-3. Create a new tag with the version number (e.g., `2.48.0` or `v2.48.0`)
-4. Fill in the release notes and publish
+1. Update the version in `mix.exs` (`@version`) and in this README (the dependency example)
+2. Merge the version bump to `develop` via a Pull Request
+3. Go to the [GitHub Releases page](https://github.com/turnhub/expression/releases)
+4. Click "Draft a new release"
+5. Create a new tag matching the version (e.g., `2.48.0`)
+6. Fill in the release notes and publish
 
-The CI workflow will automatically:
-- Update the version in `mix.exs` and `README.md` if they don't match the release tag
-- Commit those changes back to the repository
-- Publish the package to Hex.pm
+The release workflow will verify that `mix.exs` and `README.md` versions match the release tag, then publish to Hex.pm. If versions don't match, the workflow will fail with an error message.
+
+### Why Not Automate Release Version Updates in Code?
+
+Our branch protection rules require all commits to have verified signatures and be made through pull requests. 
+GitHub Actions workflows cannot satisfy these requirements.
+This is intentional: it ensures all code changes, including version bumps, go through proper review.
 
 ## Documentation
 


### PR DESCRIPTION
I tried to get smart by streamlining the release process as a single action (creating a Release on GitHub). Ended up looking like a fool!

<img width="1590" height="948" alt="CleanShot 2026-01-21 at 19 35 04@2x" src="https://github.com/user-attachments/assets/7ae3f952-85c9-4da8-819d-57083c1ffd62" />


Branch protection rules require verified signatures and PR-based changes, which GitHub Actions cannot satisfy.

So now we just fail faster instead of relying on hex and hexdocs.

I've also included a brief explanation of why we take this approach in the README.md in case someone else wants to try this in the future and will be forewarned of the hidden complexity there.

