### PR TITLE
Change CLA signatures branch to cla-signatures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/turnhub/expression/blob/develop/CLA.md" # e.g. a CLA or a DCO document
           # branch should not be protected
-          branch: "develop"
+          branch: "cla-signatures"
           allowlist: dependabot[bot],santiagocardo
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken


### PR DESCRIPTION
## Summary
- Updates CLA workflow to store signatures on `cla-signatures` branch instead of `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)