### PR TITLE
Phase 2: Developer experience — defexpr macro

### DIFF
--- a/CRITICAL_ANALYSIS.md
+++ b/CRITICAL_ANALYSIS.md
@@ -962,14 +962,14 @@ These are production safety fixes and the structural foundation everything else 
 - [x] **Add `%Expression.Context{}` struct with private state** — struct with `vars` and `private` fields. `Context.new/2` unchanged (returns plain map, passes through existing struct). New `Context.build/2` returns struct with `private:` option. Eval dual-path: struct reads from `vars`, map path unchanged. Lambdas/captures work with struct. 8 new tests verify private state isolation (`@secret` in private is not resolvable via expressions). *(Sections 8.4, 10.8)*
 - [x] **Define `Expression.Error` exception struct** — `lib/expression/error.ex` with `type`, `message`, `expression`, `position` fields. Purely additive, no existing code uses it yet. *(Section 10.1)*
 
-### Phase 2: Developer Experience
+### Phase 2: Developer Experience ✅ COMPLETE (2026-04-04)
 
-The `defexpr` macro and related ergonomics. Depends on Phase 1 (`%Expression.Context{}` must exist for context access to work).
+The `defexpr` macro and related ergonomics.
 
-- [ ] **Implement `defexpr` macro** — auto-evaluates arguments, optional context injection, compile-time function registration via `@before_compile`. Generates standard `def` under the hood. *(Sections 9.3, 9.4, 10.10)*
-- [ ] **Add compile-time consistency validation** — ensure all clauses of a `defexpr` function agree on context usage. Modeled on Lua's `validate_func!`. *(Section 9.4)*
-- [ ] **Add `@variadic true` attribute support** — replaces the `_vargs` suffix convention with an explicit attribute that auto-resets per function. *(Section 9.4)*
-- [ ] **Add `use Expression.Callbacks` composition options** — `stdlib: false` to opt out of Standard, `also: [ModuleA, ModuleB]` for multi-module dispatch. Default behavior unchanged. *(Section 9.5)*
+- [x] **Implement `defexpr` macro** — `defexpr/2` (no context) and `defexpr/3` (with context). Auto-evaluates arguments via generated `eval!` calls. Generates standard `def` under the hood. Reserved words handled: `defexpr or_(a, b)` registers as expression name `:or`. 21 new tests in `test/expression_defexpr_test.exs`. *(Sections 9.3, 9.4, 10.10)*
+- [x] **Add compile-time consistency validation** — `validate_expression_func!/3` ensures all clauses agree on context usage. `@expression_function` accumulated attribute. `@before_compile` generates `__expression_functions__/0`. *(Section 9.4)*
+- [x] **Add `@variadic true` attribute support** — read at caller's compile time via `Module.delete_attribute` inside `quote` (Lua pattern). Generates `name_vargs/2` under the hood. User's first argument name bound to raw args list. *(Section 9.4)*
+- [x] **Add `use Expression.Callbacks` composition options** — `stdlib: false` disables Standard fallback. `also: [ModuleA, ModuleB]` for multi-module dispatch via `handle_chain/4`. Default behavior unchanged. *(Section 9.5)*
 
 ### Phase 3: Error Handling Migration
 

--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -365,6 +365,27 @@ defmodule Expression.Callbacks do
   Expression function names that are Elixir reserved words (`and`, `if`,
   `or`, `not`) are automatically suffixed with `_` in the generated
   function name.
+
+  ## When NOT to use `defexpr`
+
+  `defexpr` eagerly evaluates **all** arguments before the body runs.
+  This is wrong for functions that need lazy or short-circuit evaluation:
+
+    - `if_(condition, yes, no)` — must only evaluate the matching branch
+    - `or_(a, b)` — must stop at the first truthy value
+
+  These functions must use plain `def` with manual `eval!` calls to
+  control when each argument is evaluated:
+
+      def if_(ctx, condition, yes, no) do
+        if eval!(condition, ctx),
+          do: eval!(yes, ctx),
+          else: eval!(no, ctx)
+      end
+
+  As a rule: if the function might skip evaluating some arguments
+  depending on the value of others, use `def`. If all arguments are
+  always needed, use `defexpr`.
   """
   defmacro defexpr(function_head, ctx_var, rest) do
     define_expr(function_head, ctx_var, rest)

--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -144,7 +144,8 @@ defmodule Expression.Callbacks do
 
     cond do
       not is_nil(exact) and exact in @built_in_operators ->
-        {:ok, apply(Kernel, exact, arguments |> Enum.map(&Expression.Eval.eval!(&1, context)))}
+        evaluated_args = Enum.map(arguments, &Expression.Eval.eval!(&1, context))
+        {:ok, apply(Kernel, exact, evaluated_args)}
 
       not is_nil(exact) and function_exported?(mod, exact, length(arguments) + 1) ->
         {:ok, apply(mod, exact, [context] ++ arguments)}
@@ -260,31 +261,29 @@ defmodule Expression.Callbacks do
   `or`, `not`) are automatically suffixed with `_` in the generated
   function name.
   """
-  defmacro defexpr(fa, ctx_var, rest) do
-    define_expr(fa, ctx_var, rest)
+  defmacro defexpr(function_head, ctx_var, rest) do
+    define_expr(function_head, ctx_var, rest)
   end
 
-  defmacro defexpr(fa, rest) do
-    define_expr(fa, nil, rest)
+  defmacro defexpr(function_head, rest) do
+    define_expr(function_head, nil, rest)
   end
 
-  defp define_expr(fa, ctx_var, do: body) do
-    {name, args} = decompose_fa(fa)
-    with_ctx? = ctx_var != nil
-
+  defp define_expr(function_head, ctx_var, do: body) do
     # The Elixir def name is what the user writes (e.g., or_, if_, and_, not_)
-    def_name = name
+    {def_name, args} = decompose_function_head(function_head)
+    with_ctx? = ctx_var != nil
 
     # The expression-facing name strips the _ suffix for reserved words
     # so `defexpr or_(a, b)` registers as expression function `or`
-    name_str = to_string(name)
+    name_str = to_string(def_name)
 
     expr_name =
       if String.ends_with?(name_str, "_") and
            String.trim_trailing(name_str, "_") in @reserved_words do
         String.trim_trailing(name_str, "_") |> String.to_atom()
       else
-        name
+        def_name
       end
 
     exact_ast = gen_exact_def(def_name, expr_name, args, ctx_var, with_ctx?, body)
@@ -304,11 +303,11 @@ defmodule Expression.Callbacks do
     end
   end
 
-  defp decompose_fa({:when, _, [{name, _, args} | _guards]}) do
+  defp decompose_function_head({:when, _, [{name, _, args} | _guards]}) do
     {name, args || []}
   end
 
-  defp decompose_fa({name, _, args}) do
+  defp decompose_function_head({name, _, args}) do
     {name, args || []}
   end
 

--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -90,7 +90,22 @@ defmodule Expression.Callbacks do
     end
   end
 
-  @doc false
+  @typedoc "The result of a callback function dispatch"
+  @type handle_result :: {:ok, any} | {:error, String.t()}
+
+  @typedoc "The result of checking whether a function is implemented"
+  @type implements_result ::
+          {:exact, module, atom, arity}
+          | {:vargs, module, atom, arity}
+          | {:error, String.t()}
+
+  @doc """
+  Handle a function call without falling back to `Standard`.
+
+  Used when a callback module is configured with `stdlib: false`.
+  Only checks the given module for exact-arity and vargs implementations.
+  """
+  @spec handle_without_stdlib(module, String.t(), [any], map) :: handle_result
   def handle_without_stdlib(module, function_name, arguments, context) do
     exact_function_name = atom_function_name(function_name)
     vargs_function_name = atom_function_name("#{function_name}_vargs")
@@ -98,23 +113,29 @@ defmodule Expression.Callbacks do
     Code.ensure_compiled!(module)
     Code.ensure_loaded!(module)
 
-    result =
-      cond do
-        not is_nil(exact_function_name) and
-            function_exported?(module, exact_function_name, length(arguments) + 1) ->
-          {:ok, apply(module, exact_function_name, [context] ++ arguments)}
+    cond do
+      not is_nil(exact_function_name) and
+          function_exported?(module, exact_function_name, length(arguments) + 1) ->
+        {:ok, apply(module, exact_function_name, [context] ++ arguments)}
 
-        not is_nil(vargs_function_name) and function_exported?(module, vargs_function_name, 2) ->
-          {:ok, apply(module, vargs_function_name, [context, arguments])}
+      not is_nil(vargs_function_name) and function_exported?(module, vargs_function_name, 2) ->
+        {:ok, apply(module, vargs_function_name, [context, arguments])}
 
-        true ->
-          {:error, "#{function_name} is not implemented."}
-      end
-
-    result
+      true ->
+        {:error, "#{function_name} is not implemented."}
+    end
   end
 
-  @doc false
+  @doc """
+  Handle a function call by searching through a chain of callback modules.
+
+  Checks each module in order for an exact-arity or vargs implementation.
+  Returns `{:ok, result}` from the first module that implements the function,
+  or `{:error, reason}` if no module in the chain implements it.
+
+  Used when a callback module is configured with `also: [ModA, ModB]`.
+  """
+  @spec handle_chain([module], String.t(), [any], map) :: handle_result
   def handle_chain(modules, function_name, arguments, context) do
     exact_function_name = atom_function_name(function_name)
     vargs_function_name = atom_function_name("#{function_name}_vargs")
@@ -129,19 +150,35 @@ defmodule Expression.Callbacks do
     if is_nil(exact_function_name) and is_nil(vargs_function_name) do
       {:error, "#{function_name} is not implemented."}
     else
-      find_in_chain(modules, function_name, exact_function_name, vargs_function_name, arguments,
-        context: context
+      find_in_chain(
+        modules,
+        function_name,
+        exact_function_name,
+        vargs_function_name,
+        arguments,
+        context
       )
     end
   end
 
-  defp find_in_chain([], function_name, _exact, _vargs, _arguments, _opts) do
+  @doc """
+  Walk a list of callback modules looking for one that implements the
+  given function.
+
+  Tries each module in order. For each module, checks:
+  1. Built-in operators (`:+`, `:-`, etc.) — dispatched to `Kernel`
+  2. Exact-arity match — `module.function(ctx, arg1, arg2, ...)`
+  3. Variable-args match — `module.function_vargs(ctx, [arg1, arg2, ...])`
+
+  Returns `{:ok, result}` from the first match, or `{:error, reason}`
+  when the list is exhausted.
+  """
+  @spec find_in_chain([module], String.t(), atom | nil, atom | nil, [any], map) :: handle_result
+  def find_in_chain([], function_name, _exact, _vargs, _arguments, _context) do
     {:error, "#{function_name} is not implemented."}
   end
 
-  defp find_in_chain([mod | rest], function_name, exact, vargs, arguments, opts) do
-    context = Keyword.fetch!(opts, :context)
-
+  def find_in_chain([mod | rest], function_name, exact, vargs, arguments, context) do
     cond do
       not is_nil(exact) and exact in @built_in_operators ->
         evaluated_args = Enum.map(arguments, &Expression.Eval.eval!(&1, context))
@@ -154,10 +191,19 @@ defmodule Expression.Callbacks do
         {:ok, apply(mod, vargs, [context, arguments])}
 
       true ->
-        find_in_chain(rest, function_name, exact, vargs, arguments, opts)
+        find_in_chain(rest, function_name, exact, vargs, arguments, context)
     end
   end
 
+  @doc """
+  Check whether a function is implemented in the given module or in `Standard`.
+
+  Returns a tagged tuple describing where and how the function is implemented:
+  - `{:exact, module, function_atom, arity}` — exact arity match
+  - `{:vargs, module, function_atom, 2}` — variable arguments match
+  - `{:error, reason}` — not found or wrong arity
+  """
+  @spec implements(module, String.t(), [any]) :: implements_result
   def implements(module \\ Standard, function_name, arguments) do
     # Make sure the module supplied and the default module are compiled
     # & loaded before attempting to find out what functions it may
@@ -176,12 +222,38 @@ defmodule Expression.Callbacks do
     if is_nil(exact_function_name) and is_nil(vargs_function_name) do
       {:error, "#{function_name} is not implemented."}
     else
-      do_implements(module, function_name, exact_function_name, vargs_function_name, arguments)
+      resolve_implementation(
+        module,
+        function_name,
+        exact_function_name,
+        vargs_function_name,
+        arguments
+      )
     end
   end
 
+  @doc """
+  Resolve which module and calling convention implements a function.
+
+  Checks in priority order:
+  1. Built-in operators in the custom module
+  2. Exact-arity in the custom module
+  3. Variable-args in the custom module
+  4. Exact-arity in `Standard`
+  5. Variable-args in `Standard`
+  6. Wrong-arity error (function exists but with different arity)
+  7. Not implemented error
+  """
+  @spec resolve_implementation(module, String.t(), atom | nil, atom | nil, [any]) ::
+          implements_result
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
-  defp do_implements(module, function_name, exact_function_name, vargs_function_name, arguments) do
+  def resolve_implementation(
+        module,
+        function_name,
+        exact_function_name,
+        vargs_function_name,
+        arguments
+      ) do
     cond do
       not is_nil(exact_function_name) and exact_function_name in @built_in_operators ->
         {:exact, module, exact_function_name, 2}
@@ -218,10 +290,18 @@ defmodule Expression.Callbacks do
     end
   end
 
-  defp wrong_arity_but_function_exists?(_module, nil), do: false
+  @doc """
+  Check whether a module defines a function with the given name at any arity,
+  even if the specific arity being requested doesn't match.
 
-  defp wrong_arity_but_function_exists?(module, function_name)
-       when is_atom(module) and is_atom(function_name) do
+  Used to produce "wrong number of arguments" errors instead of
+  "not implemented" errors.
+  """
+  @spec wrong_arity_but_function_exists?(module, atom | nil) :: boolean
+  def wrong_arity_but_function_exists?(_module, nil), do: false
+
+  def wrong_arity_but_function_exists?(module, function_name)
+      when is_atom(module) and is_atom(function_name) do
     module.__info__(:functions)[function_name] != nil
   end
 

--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -3,19 +3,46 @@ defmodule Expression.Callbacks do
   Use this module to implement one's own callbacks.
   The standard callbacks available are implemented in `Expression.Callbacks.Standard`.
 
+  ## Using `defexpr`
+
+  `defexpr` auto-evaluates arguments from their AST form before the body executes:
+
   ```elixir
   defmodule MyCallbacks do
     use Expression.Callbacks
 
-    @doc \"\"\"
-    Roll a dice and randomly return a number between 1 and 6.
-    \"\"\"
-    def dice_roll(ctx) do
+    defexpr dice_roll() do
       Enum.random(1..6)
     end
 
+    defexpr greet(name), ctx do
+      prefix = ctx.private[:prefix] || "Hello"
+      "\#{prefix}, \#{name}!"
+    end
   end
   ```
+
+  ## Using plain `def`
+
+  Traditional `def` callbacks still work — `defexpr` is optional sugar.
+  With plain `def`, you must manually call `eval!` on each argument:
+
+  ```elixir
+  defmodule MyCallbacks do
+    use Expression.Callbacks
+
+    def dice_roll(_ctx) do
+      Enum.random(1..6)
+    end
+  end
+  ```
+
+  ## Options
+
+    * `stdlib: false` — don't fall back to `Expression.Callbacks.Standard`
+    * `also: [ModuleA, ModuleB]` — compose multiple callback modules;
+      dispatch checks each in order before falling back to Standard
+
   """
 
   alias Expression.Callbacks.Standard
@@ -60,6 +87,73 @@ defmodule Expression.Callbacks do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  @doc false
+  def handle_without_stdlib(module, function_name, arguments, context) do
+    exact_function_name = atom_function_name(function_name)
+    vargs_function_name = atom_function_name("#{function_name}_vargs")
+
+    Code.ensure_compiled!(module)
+    Code.ensure_loaded!(module)
+
+    result =
+      cond do
+        not is_nil(exact_function_name) and
+            function_exported?(module, exact_function_name, length(arguments) + 1) ->
+          {:ok, apply(module, exact_function_name, [context] ++ arguments)}
+
+        not is_nil(vargs_function_name) and function_exported?(module, vargs_function_name, 2) ->
+          {:ok, apply(module, vargs_function_name, [context, arguments])}
+
+        true ->
+          {:error, "#{function_name} is not implemented."}
+      end
+
+    result
+  end
+
+  @doc false
+  def handle_chain(modules, function_name, arguments, context) do
+    exact_function_name = atom_function_name(function_name)
+    vargs_function_name = atom_function_name("#{function_name}_vargs")
+
+    modules
+    |> Enum.uniq()
+    |> Enum.each(fn mod ->
+      Code.ensure_compiled!(mod)
+      Code.ensure_loaded!(mod)
+    end)
+
+    if is_nil(exact_function_name) and is_nil(vargs_function_name) do
+      {:error, "#{function_name} is not implemented."}
+    else
+      find_in_chain(modules, function_name, exact_function_name, vargs_function_name, arguments,
+        context: context
+      )
+    end
+  end
+
+  defp find_in_chain([], function_name, _exact, _vargs, _arguments, _opts) do
+    {:error, "#{function_name} is not implemented."}
+  end
+
+  defp find_in_chain([mod | rest], function_name, exact, vargs, arguments, opts) do
+    context = Keyword.fetch!(opts, :context)
+
+    cond do
+      not is_nil(exact) and exact in @built_in_operators ->
+        {:ok, apply(Kernel, exact, arguments |> Enum.map(&Expression.Eval.eval!(&1, context)))}
+
+      not is_nil(exact) and function_exported?(mod, exact, length(arguments) + 1) ->
+        {:ok, apply(mod, exact, [context] ++ arguments)}
+
+      not is_nil(vargs) and function_exported?(mod, vargs, 2) ->
+        {:ok, apply(mod, vargs, [context, arguments])}
+
+      true ->
+        find_in_chain(rest, function_name, exact, vargs, arguments, opts)
     end
   end
 
@@ -130,12 +224,247 @@ defmodule Expression.Callbacks do
     module.__info__(:functions)[function_name] != nil
   end
 
-  defmacro __using__(_opts) do
+  @doc """
+  Macro for defining expression callback functions with automatic
+  argument evaluation.
+
+  ## Without context (pure functions)
+
+      defexpr upper(text) do
+        String.upcase(to_string(text))
+      end
+
+  Generates a standard callback where `text` is automatically
+  evaluated from its AST form before the body executes.
+
+  ## With context access
+
+      defexpr generate_ott(data), ctx do
+        with %{number: number} <- ctx.private, ...
+      end
+
+  The second argument names the context variable, giving access to
+  `ctx.vars`, `ctx.private`, and the full `Expression.Context` struct
+  (or plain map for legacy callers).
+
+  ## Variadic functions
+
+      @variadic true
+      defexpr switch(args), ctx do
+        # args is a list of all pre-evaluated arguments
+      end
+
+  ## Reserved words
+
+  Expression function names that are Elixir reserved words (`and`, `if`,
+  `or`, `not`) are automatically suffixed with `_` in the generated
+  function name.
+  """
+  defmacro defexpr(fa, ctx_var, rest) do
+    define_expr(fa, ctx_var, rest)
+  end
+
+  defmacro defexpr(fa, rest) do
+    define_expr(fa, nil, rest)
+  end
+
+  defp define_expr(fa, ctx_var, do: body) do
+    {name, args} = decompose_fa(fa)
+    with_ctx? = ctx_var != nil
+
+    # The Elixir def name is what the user writes (e.g., or_, if_, and_, not_)
+    def_name = name
+
+    # The expression-facing name strips the _ suffix for reserved words
+    # so `defexpr or_(a, b)` registers as expression function `or`
+    name_str = to_string(name)
+
+    expr_name =
+      if String.ends_with?(name_str, "_") and
+           String.trim_trailing(name_str, "_") in @reserved_words do
+        String.trim_trailing(name_str, "_") |> String.to_atom()
+      else
+        name
+      end
+
+    exact_ast = gen_exact_def(def_name, expr_name, args, ctx_var, with_ctx?, body)
+    vargs_def_name = :"#{def_name}_vargs"
+    user_args_var = List.first(args)
+
+    variadic_ast =
+      gen_variadic_def(vargs_def_name, expr_name, user_args_var, ctx_var, with_ctx?, body)
+
+    # Read @variadic at caller's compile time (like Lua does)
+    quote do
+      if Module.delete_attribute(__MODULE__, :variadic) do
+        unquote(variadic_ast)
+      else
+        unquote(exact_ast)
+      end
+    end
+  end
+
+  defp decompose_fa({:when, _, [{name, _, args} | _guards]}) do
+    {name, args || []}
+  end
+
+  defp decompose_fa({name, _, args}) do
+    {name, args || []}
+  end
+
+  defp gen_exact_def(def_name, expr_name, args, ctx_var, with_ctx?, body) do
+    ast_args = Enum.map(args, fn {arg_name, _, _} -> Macro.var(:"#{arg_name}_ast__", nil) end)
+    ctx_param = Macro.var(:expr_ctx__, nil)
+
+    eval_mod = Expression.Callbacks.EvalHelpers
+
+    eval_bindings =
+      Enum.zip(args, ast_args)
+      |> Enum.map(fn {{arg_name, _, _}, ast_var} ->
+        quote do
+          unquote(Macro.var(arg_name, nil)) =
+            unquote(eval_mod).eval!(unquote(ast_var), unquote(ctx_param))
+        end
+      end)
+
+    ctx_binding =
+      if with_ctx? do
+        [quote(do: unquote(ctx_var) = unquote(ctx_param))]
+      else
+        []
+      end
+
+    full_body =
+      quote do
+        unquote_splicing(ctx_binding)
+        unquote_splicing(eval_bindings)
+        unquote(body)
+      end
+
+    quote do
+      @expression_function Expression.Callbacks.validate_expression_func!(
+                             {unquote(expr_name), unquote(with_ctx?), false},
+                             __MODULE__,
+                             @expression_function
+                           )
+      def unquote(def_name)(unquote(ctx_param), unquote_splicing(ast_args)) do
+        unquote(full_body)
+      end
+    end
+  end
+
+  defp gen_variadic_def(def_name, expr_name, user_args_var, ctx_var, with_ctx?, body) do
+    ctx_param = Macro.var(:expr_ctx__, nil)
+
+    ctx_binding =
+      if with_ctx? do
+        [quote(do: unquote(ctx_var) = unquote(ctx_param))]
+      else
+        []
+      end
+
+    full_body =
+      quote do
+        unquote_splicing(ctx_binding)
+        unquote(body)
+      end
+
+    # The user's first argument name gets bound to the raw arguments list
+    quote do
+      @expression_function Expression.Callbacks.validate_expression_func!(
+                             {unquote(expr_name), unquote(with_ctx?), true},
+                             __MODULE__,
+                             @expression_function
+                           )
+      def unquote(def_name)(unquote(ctx_param), unquote(user_args_var)) do
+        unquote(full_body)
+      end
+    end
+  end
+
+  @doc false
+  def validate_expression_func!({name, with_ctx?, variadic?}, module, existing) do
+    conflict =
+      Enum.find(existing, fn
+        {^name, other_ctx?, _} -> other_ctx? != with_ctx?
+        _ -> false
+      end)
+
+    if conflict do
+      raise CompileError,
+        description:
+          "#{inspect(module)}.#{name} has inconsistent context usage across clauses. " <>
+            "All defexpr clauses for the same function must consistently use or omit context."
+    end
+
+    {name, with_ctx?, variadic?}
+  end
+
+  defmacro __using__(opts \\ []) do
+    also_modules = Keyword.get(opts, :also, [])
+    stdlib? = Keyword.get(opts, :stdlib, true)
+
+    handle_def =
+      if also_modules == [] do
+        # Default: delegate to Expression.Callbacks (checks self, then Standard)
+        if stdlib? do
+          quote do
+            defdelegate handle(module \\ __MODULE__, function_name, arguments, context),
+              to: Expression.Callbacks
+          end
+        else
+          quote do
+            def handle(module \\ __MODULE__, function_name, arguments, context) do
+              Expression.Callbacks.handle_without_stdlib(
+                module,
+                function_name,
+                arguments,
+                context
+              )
+            end
+          end
+        end
+      else
+        # Compose: check self, then each `also` module, then Standard (if enabled)
+        modules =
+          if stdlib?,
+            do: also_modules ++ [Expression.Callbacks.Standard],
+            else: also_modules
+
+        quote do
+          def handle(module \\ __MODULE__, function_name, arguments, context) do
+            Expression.Callbacks.handle_chain(
+              [module | unquote(modules)],
+              function_name,
+              arguments,
+              context
+            )
+          end
+        end
+      end
+
     quote do
       import Expression.Callbacks.EvalHelpers
+      import Expression.Callbacks, only: [defexpr: 2, defexpr: 3]
 
-      defdelegate handle(module \\ __MODULE__, function_name, arguments, context),
-        to: Expression.Callbacks
+      Module.register_attribute(__MODULE__, :expression_function, accumulate: true)
+      @before_compile Expression.Callbacks
+
+      unquote(handle_def)
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    functions =
+      env.module
+      |> Module.get_attribute(:expression_function)
+      |> Enum.uniq()
+      |> Enum.reverse()
+
+    quote do
+      def __expression_functions__ do
+        unquote(Macro.escape(functions))
+      end
     end
   end
 end

--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -225,6 +225,31 @@ defmodule Expression.Callbacks do
     module.__info__(:functions)[function_name] != nil
   end
 
+  # ── Metaprogramming glossary ────────────────────────────────────────
+  #
+  # If you're not familiar with Elixir macros, here's a quick reference
+  # for the four tools used in the code below:
+  #
+  #   quote do ... end
+  #     Captures a block of Elixir code as its AST representation
+  #     (a nested tuple structure) instead of executing it. Think of
+  #     it as "template this code for later."
+  #
+  #   unquote(value)
+  #     Inside a `quote` block, injects a compile-time value into the
+  #     template. Like string interpolation but for code.
+  #
+  #   unquote_splicing(list)
+  #     Like `unquote`, but splices a list of AST nodes inline.
+  #     Turns [a, b, c] into three separate statements.
+  #
+  #   Macro.var(name, nil)
+  #     Creates a variable reference in the AST. The `nil` context
+  #     makes it "hygienic" — it won't collide with variables the
+  #     user defined in their code.
+  #
+  # ───────────────────────────────────────────────────────────────────
+
   @doc """
   Macro for defining expression callback functions with automatic
   argument evaluation.
@@ -269,31 +294,43 @@ defmodule Expression.Callbacks do
     define_expr(function_head, nil, rest)
   end
 
+  # ── Code generation entry point ───────────────────────────────────
+  #
+  # `define_expr` is the main orchestrator. It:
+  #   1. Extracts the function name and arguments from the function head
+  #   2. Determines the expression-facing name (stripping reserved word suffixes)
+  #   3. Generates both exact-arity and variadic versions of the function
+  #   4. Emits a compile-time `if` that picks the right one based on @variadic
+  #
   defp define_expr(function_head, ctx_var, do: body) do
-    # The Elixir def name is what the user writes (e.g., or_, if_, and_, not_)
     {def_name, args} = decompose_function_head(function_head)
     with_ctx? = ctx_var != nil
-
-    # The expression-facing name strips the _ suffix for reserved words
-    # so `defexpr or_(a, b)` registers as expression function `or`
-    name_str = to_string(def_name)
-
-    expr_name =
-      if String.ends_with?(name_str, "_") and
-           String.trim_trailing(name_str, "_") in @reserved_words do
-        String.trim_trailing(name_str, "_") |> String.to_atom()
-      else
-        def_name
-      end
+    expr_name = expression_facing_name(def_name)
 
     exact_ast = gen_exact_def(def_name, expr_name, args, ctx_var, with_ctx?, body)
+
     vargs_def_name = :"#{def_name}_vargs"
     user_args_var = List.first(args)
 
     variadic_ast =
       gen_variadic_def(vargs_def_name, expr_name, user_args_var, ctx_var, with_ctx?, body)
 
-    # Read @variadic at caller's compile time (like Lua does)
+    # ── Why Module.delete_attribute is inside `quote` ──────────────
+    #
+    # Code inside `quote do ... end` runs at the *caller module's*
+    # compile time, not when this macro is expanded. We need to read
+    # @variadic at that moment because:
+    #
+    #   @variadic true          # ← set by the user right before defexpr
+    #   defexpr concat(args)... # ← macro expands here
+    #
+    # `Module.delete_attribute(__MODULE__, :variadic)` reads the value
+    # AND clears it in one step (so it doesn't leak to the next defexpr).
+    # If @variadic was set, it returns `true` and we emit the variadic
+    # function. Otherwise we emit the exact-arity function.
+    #
+    # This pattern comes from the Lua package's `deflua` macro.
+    #
     quote do
       if Module.delete_attribute(__MODULE__, :variadic) do
         unquote(variadic_ast)
@@ -303,6 +340,11 @@ defmodule Expression.Callbacks do
     end
   end
 
+  # Extracts {name, args} from the function head AST.
+  #
+  #   decompose_function_head(quote(do: foo(a, b)))
+  #   #=> {:foo, [{:a, [], nil}, {:b, [], nil}]}
+  #
   defp decompose_function_head({:when, _, [{name, _, args} | _guards]}) do
     {name, args || []}
   end
@@ -311,27 +353,48 @@ defmodule Expression.Callbacks do
     {name, args || []}
   end
 
+  # The expression-facing name strips the `_` suffix for reserved words.
+  # Users write `defexpr or_(a, b)` (because `or` is an Elixir keyword),
+  # but the expression language knows it as `or`.
+  defp expression_facing_name(def_name) do
+    name_str = to_string(def_name)
+
+    if String.ends_with?(name_str, "_") and
+         String.trim_trailing(name_str, "_") in @reserved_words do
+      name_str |> String.trim_trailing("_") |> String.to_atom()
+    else
+      def_name
+    end
+  end
+
+  # ── Exact-arity function generation ───────────────────────────────
+  #
+  # Given this input:
+  #
+  #     defexpr chunk_every(enumerable, count), ctx do
+  #       Enum.chunk_every(enumerable, count)
+  #     end
+  #
+  # Generates this output:
+  #
+  #     @expression_function {:chunk_every, true, false}
+  #     def chunk_every(expr_ctx__, enumerable_ast__, count_ast__) do
+  #       ctx = expr_ctx__
+  #       enumerable = Expression.Callbacks.EvalHelpers.eval!(enumerable_ast__, expr_ctx__)
+  #       count = Expression.Callbacks.EvalHelpers.eval!(count_ast__, expr_ctx__)
+  #       Enum.chunk_every(enumerable, count)
+  #     end
+  #
+  # The key transformation: each user argument (e.g. `enumerable`) gets
+  # a hidden `_ast__` parameter in the actual function signature, and a
+  # binding at the top of the body that evaluates it. The user's code
+  # then sees `enumerable` as an already-evaluated value.
+  #
   defp gen_exact_def(def_name, expr_name, args, ctx_var, with_ctx?, body) do
-    ast_args = Enum.map(args, fn {arg_name, _, _} -> Macro.var(:"#{arg_name}_ast__", nil) end)
-    ctx_param = Macro.var(:expr_ctx__, nil)
-
-    eval_mod = Expression.Callbacks.EvalHelpers
-
-    eval_bindings =
-      Enum.zip(args, ast_args)
-      |> Enum.map(fn {{arg_name, _, _}, ast_var} ->
-        quote do
-          unquote(Macro.var(arg_name, nil)) =
-            unquote(eval_mod).eval!(unquote(ast_var), unquote(ctx_param))
-        end
-      end)
-
-    ctx_binding =
-      if with_ctx? do
-        [quote(do: unquote(ctx_var) = unquote(ctx_param))]
-      else
-        []
-      end
+    ctx_param = hygienic_var(:expr_ctx__)
+    ast_params = build_ast_params(args)
+    eval_bindings = build_eval_bindings(args, ast_params, ctx_param)
+    ctx_binding = build_ctx_binding(ctx_var, ctx_param, with_ctx?)
 
     full_body =
       quote do
@@ -346,21 +409,37 @@ defmodule Expression.Callbacks do
                              __MODULE__,
                              @expression_function
                            )
-      def unquote(def_name)(unquote(ctx_param), unquote_splicing(ast_args)) do
+      def unquote(def_name)(unquote(ctx_param), unquote_splicing(ast_params)) do
         unquote(full_body)
       end
     end
   end
 
+  # ── Variadic function generation ──────────────────────────────────
+  #
+  # Given this input:
+  #
+  #     @variadic true
+  #     defexpr concat(args), ctx do
+  #       Enum.map_join(args, "", &EvalHelpers.eval!(&1, ctx))
+  #     end
+  #
+  # Generates this output:
+  #
+  #     @expression_function {:concat, true, true}
+  #     def concat_vargs(expr_ctx__, args) do
+  #       ctx = expr_ctx__
+  #       Enum.map_join(args, "", &EvalHelpers.eval!(&1, ctx))
+  #     end
+  #
+  # The user's first argument name (`args`) is bound directly to the
+  # raw arguments list. Unlike exact-arity functions, arguments are NOT
+  # auto-evaluated — the user controls evaluation (since the argument
+  # count is dynamic).
+  #
   defp gen_variadic_def(def_name, expr_name, user_args_var, ctx_var, with_ctx?, body) do
-    ctx_param = Macro.var(:expr_ctx__, nil)
-
-    ctx_binding =
-      if with_ctx? do
-        [quote(do: unquote(ctx_var) = unquote(ctx_param))]
-      else
-        []
-      end
+    ctx_param = hygienic_var(:expr_ctx__)
+    ctx_binding = build_ctx_binding(ctx_var, ctx_param, with_ctx?)
 
     full_body =
       quote do
@@ -368,7 +447,6 @@ defmodule Expression.Callbacks do
         unquote(body)
       end
 
-    # The user's first argument name gets bound to the raw arguments list
     quote do
       @expression_function Expression.Callbacks.validate_expression_func!(
                              {unquote(expr_name), unquote(with_ctx?), true},
@@ -380,6 +458,47 @@ defmodule Expression.Callbacks do
       end
     end
   end
+
+  # ── Helpers for code generation ───────────────────────────────────
+
+  # Creates a variable reference that won't collide with user-defined
+  # variables. The `nil` context makes it hygienic — even if the user
+  # has a variable called `expr_ctx__`, it won't conflict.
+  defp hygienic_var(name), do: Macro.var(name, nil)
+
+  # For each user argument like `text`, creates a corresponding hidden
+  # parameter like `text_ast__` that will appear in the generated
+  # function signature.
+  defp build_ast_params(args) do
+    Enum.map(args, fn {arg_name, _, _} ->
+      hygienic_var(:"#{arg_name}_ast__")
+    end)
+  end
+
+  # Generates the `arg = eval!(arg_ast__, ctx)` bindings that appear
+  # at the top of the function body, one per argument.
+  defp build_eval_bindings(args, ast_params, ctx_param) do
+    eval_mod = Expression.Callbacks.EvalHelpers
+
+    Enum.zip(args, ast_params)
+    |> Enum.map(fn {{arg_name, _, _}, ast_var} ->
+      quote do
+        unquote(Macro.var(arg_name, nil)) =
+          unquote(eval_mod).eval!(unquote(ast_var), unquote(ctx_param))
+      end
+    end)
+  end
+
+  # If the user requested context access (`defexpr foo(a), ctx do`),
+  # generates `ctx = expr_ctx__` so the user's chosen name is bound.
+  # If not, returns an empty list (no binding generated).
+  defp build_ctx_binding(_ctx_var, _ctx_param, false = _with_ctx?), do: []
+
+  defp build_ctx_binding(ctx_var, ctx_param, true = _with_ctx?) do
+    [quote(do: unquote(ctx_var) = unquote(ctx_param))]
+  end
+
+  # ── Compile-time validation ───────────────────────────────────────
 
   @doc false
   def validate_expression_func!({name, with_ctx?, variadic?}, module, existing) do

--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -465,6 +465,18 @@ defmodule Expression.Callbacks do
   #       Enum.chunk_every(enumerable, count)
   #     end
   #
+  # The `@expression_function` attribute is an accumulating module
+  # attribute that registers metadata about each defexpr function.
+  # The tuple `{:chunk_every, true, false}` means:
+  #   - :chunk_every  — the expression-facing function name
+  #   - true          — this function uses context (defexpr/3)
+  #   - false         — this is NOT a variadic function
+  #
+  # At compile time, `@before_compile` collects all these tuples and
+  # generates `__expression_functions__/0`, which returns the full
+  # list. This enables introspection — e.g. listing all registered
+  # callbacks, checking context usage, or building documentation.
+  #
   # The key transformation: each user argument (e.g. `enumerable`) gets
   # a hidden `_ast__` parameter in the actual function signature, and a
   # binding at the top of the body that evaluates it. The user's code
@@ -507,6 +519,7 @@ defmodule Expression.Callbacks do
   # Generates this output:
   #
   #     @expression_function {:concat, true, true}
+  #                          # ↑ name   ↑ ctx  ↑ variadic=true
   #     def concat_vargs(expr_ctx__, args) do
   #       ctx = expr_ctx__
   #       Enum.map_join(args, "", &EvalHelpers.eval!(&1, ctx))

--- a/lib/expression/callbacks.ex
+++ b/lib/expression/callbacks.ex
@@ -150,7 +150,7 @@ defmodule Expression.Callbacks do
     if is_nil(exact_function_name) and is_nil(vargs_function_name) do
       {:error, "#{function_name} is not implemented."}
     else
-      find_in_chain(
+      apply_first_in_chain(
         modules,
         function_name,
         exact_function_name,
@@ -173,12 +173,13 @@ defmodule Expression.Callbacks do
   Returns `{:ok, result}` from the first match, or `{:error, reason}`
   when the list is exhausted.
   """
-  @spec find_in_chain([module], String.t(), atom | nil, atom | nil, [any], map) :: handle_result
-  def find_in_chain([], function_name, _exact, _vargs, _arguments, _context) do
+  @spec apply_first_in_chain([module], String.t(), atom | nil, atom | nil, [any], map) ::
+          handle_result
+  def apply_first_in_chain([], function_name, _exact, _vargs, _arguments, _context) do
     {:error, "#{function_name} is not implemented."}
   end
 
-  def find_in_chain([mod | rest], function_name, exact, vargs, arguments, context) do
+  def apply_first_in_chain([mod | rest], function_name, exact, vargs, arguments, context) do
     cond do
       not is_nil(exact) and exact in @built_in_operators ->
         evaluated_args = Enum.map(arguments, &Expression.Eval.eval!(&1, context))
@@ -191,7 +192,7 @@ defmodule Expression.Callbacks do
         {:ok, apply(mod, vargs, [context, arguments])}
 
       true ->
-        find_in_chain(rest, function_name, exact, vargs, arguments, context)
+        apply_first_in_chain(rest, function_name, exact, vargs, arguments, context)
     end
   end
 
@@ -413,9 +414,6 @@ defmodule Expression.Callbacks do
     vargs_def_name = :"#{def_name}_vargs"
     user_args_var = List.first(args)
 
-    variadic_ast =
-      gen_variadic_def(vargs_def_name, expr_name, user_args_var, ctx_var, with_ctx?, body)
-
     # ── Why Module.delete_attribute is inside `quote` ──────────────
     #
     # Code inside `quote do ... end` runs at the *caller module's*
@@ -434,7 +432,9 @@ defmodule Expression.Callbacks do
     #
     quote do
       if Module.delete_attribute(__MODULE__, :variadic) do
-        unquote(variadic_ast)
+        unquote(
+          gen_variadic_def(vargs_def_name, expr_name, user_args_var, ctx_var, with_ctx?, body)
+        )
       else
         unquote(exact_ast)
       end
@@ -618,7 +618,7 @@ defmodule Expression.Callbacks do
   def validate_expression_func!({name, with_ctx?, variadic?}, module, existing) do
     conflict =
       Enum.find(existing, fn
-        {^name, other_ctx?, _} -> other_ctx? != with_ctx?
+        {^name, other_with_ctx?, _} -> other_with_ctx? != with_ctx?
         _ -> false
       end)
 

--- a/test/expression_defexpr_test.exs
+++ b/test/expression_defexpr_test.exs
@@ -1,0 +1,217 @@
+defmodule ExpressionDefexprTest do
+  use ExUnit.Case, async: true
+
+  # A callback module using only defexpr — no manual def callbacks
+  defmodule DefexprCallbacks do
+    use Expression.Callbacks
+
+    defexpr shout(text) do
+      String.upcase(to_string(text))
+    end
+
+    defexpr add(a, b) do
+      a + b
+    end
+
+    # With context access
+    defexpr greet(name), ctx do
+      prefix =
+        case ctx do
+          %Expression.Context{private: %{prefix: p}} -> p
+          _ -> "Hello"
+        end
+
+      "#{prefix}, #{name}!"
+    end
+
+    # Reserved word: user writes `or_`, macro registers as expression name `or`
+    defexpr or_(a, b) do
+      a || b
+    end
+
+    # Variadic function
+    @variadic true
+    defexpr concat(args), ctx do
+      args
+      |> Enum.map(&Expression.Callbacks.EvalHelpers.eval!(&1, ctx))
+      |> Enum.join("")
+    end
+  end
+
+  # A callback module that mixes defexpr and regular def
+  defmodule MixedCallbacks do
+    use Expression.Callbacks
+
+    # defexpr style
+    defexpr double(n) do
+      n * 2
+    end
+
+    # traditional def style — still works
+    def triple(ctx, n) do
+      eval!(n, ctx) * 3
+    end
+  end
+
+  # A callback module with stdlib: false
+  defmodule NoStdlibCallbacks do
+    use Expression.Callbacks, stdlib: false
+
+    defexpr echo(text) do
+      "echo: #{text}"
+    end
+  end
+
+  # Callback modules for composition
+  defmodule MathCallbacks do
+    use Expression.Callbacks, stdlib: false
+
+    defexpr square(n) do
+      n * n
+    end
+  end
+
+  defmodule StringCallbacks do
+    use Expression.Callbacks, stdlib: false
+
+    defexpr reverse(text) do
+      text |> to_string() |> String.reverse()
+    end
+  end
+
+  defmodule ComposedCallbacks do
+    use Expression.Callbacks, also: [MathCallbacks, StringCallbacks]
+
+    defexpr custom_hello(name) do
+      "hello #{name}"
+    end
+  end
+
+  describe "defexpr/2 (no context)" do
+    test "simple single-arg function" do
+      assert {:ok, "FOO"} = Expression.evaluate("@shout(\"foo\")", %{}, DefexprCallbacks)
+    end
+
+    test "multi-arg function" do
+      assert {:ok, 7} = Expression.evaluate("@(add(3, 4))", %{}, DefexprCallbacks)
+    end
+
+    test "with variable substitution" do
+      assert {:ok, "HELLO"} =
+               Expression.evaluate("@shout(name)", %{"name" => "hello"}, DefexprCallbacks)
+    end
+  end
+
+  describe "defexpr/3 (with context)" do
+    test "accesses private state from structured context" do
+      ctx = Expression.Context.build(%{"name" => "Jane"}, private: %{prefix: "Hi"})
+      assert "Hi, Jane!" == Expression.evaluate_as_string!("@greet(name)", ctx, DefexprCallbacks)
+    end
+
+    test "falls back gracefully with plain map context" do
+      assert {:ok, "Hello, Jane!"} =
+               Expression.evaluate("@greet(\"Jane\")", %{}, DefexprCallbacks)
+    end
+  end
+
+  describe "reserved words" do
+    test "or function works through defexpr" do
+      assert {:ok, true} =
+               Expression.evaluate("@(or(false, true))", %{}, DefexprCallbacks)
+    end
+
+    test "or with truthy first argument" do
+      assert {:ok, "yes"} =
+               Expression.evaluate("@(or(\"yes\", \"no\"))", %{}, DefexprCallbacks)
+    end
+  end
+
+  describe "@variadic" do
+    test "variadic function receives argument list" do
+      assert {:ok, "abc"} =
+               Expression.evaluate("@concat(\"a\", \"b\", \"c\")", %{}, DefexprCallbacks)
+    end
+  end
+
+  describe "mixed defexpr and def" do
+    test "defexpr function works" do
+      assert {:ok, 10} = Expression.evaluate("@(double(5))", %{}, MixedCallbacks)
+    end
+
+    test "traditional def function works alongside defexpr" do
+      assert {:ok, 15} = Expression.evaluate("@(triple(5))", %{}, MixedCallbacks)
+    end
+
+    test "stdlib fallback still works" do
+      assert {:ok, "FOO"} = Expression.evaluate("@upper(\"foo\")", %{}, MixedCallbacks)
+    end
+  end
+
+  describe "stdlib: false" do
+    test "custom function works" do
+      assert {:ok, "echo: hi"} =
+               Expression.evaluate("@echo(\"hi\")", %{}, NoStdlibCallbacks)
+    end
+
+    test "stdlib functions are not available" do
+      assert {:ok, result} = Expression.evaluate("@upper(\"foo\")", %{}, NoStdlibCallbacks)
+      assert result =~ "ERROR"
+    end
+  end
+
+  describe "also: composition" do
+    test "own functions work" do
+      assert {:ok, "hello world"} =
+               Expression.evaluate("@custom_hello(\"world\")", %{}, ComposedCallbacks)
+    end
+
+    test "also modules are available" do
+      assert {:ok, 25} = Expression.evaluate("@(square(5))", %{}, ComposedCallbacks)
+    end
+
+    test "multiple also modules compose" do
+      assert {:ok, "oof"} = Expression.evaluate("@reverse(\"foo\")", %{}, ComposedCallbacks)
+    end
+
+    test "stdlib still available as final fallback" do
+      assert {:ok, "FOO"} = Expression.evaluate("@upper(\"foo\")", %{}, ComposedCallbacks)
+    end
+  end
+
+  describe "__expression_functions__/0" do
+    test "registered functions are listed" do
+      funcs = DefexprCallbacks.__expression_functions__()
+      names = Enum.map(funcs, &elem(&1, 0))
+
+      assert :shout in names
+      assert :add in names
+      assert :greet in names
+      assert :or in names
+      assert :concat in names
+    end
+
+    test "context usage is tracked" do
+      funcs = DefexprCallbacks.__expression_functions__()
+
+      shout = Enum.find(funcs, &(elem(&1, 0) == :shout))
+      assert {_, false, false} = shout
+
+      greet = Enum.find(funcs, &(elem(&1, 0) == :greet))
+      assert {_, true, false} = greet
+    end
+
+    test "variadic is tracked" do
+      funcs = DefexprCallbacks.__expression_functions__()
+      concat = Enum.find(funcs, &(elem(&1, 0) == :concat))
+      assert {_, true, true} = concat
+    end
+  end
+
+  describe "backwards compatibility" do
+    test "existing custom callbacks test still passes with custom def" do
+      # The CustomCallback from expression_custom_callbacks_test.exs uses def, not defexpr
+      # This test ensures the __using__ changes don't break existing modules
+      assert {:ok, "FOO"} = Expression.evaluate("@upper(\"foo\")", %{}, MixedCallbacks)
+    end
+  end
+end

--- a/test/expression_defexpr_test.exs
+++ b/test/expression_defexpr_test.exs
@@ -24,9 +24,9 @@ defmodule ExpressionDefexprTest do
       "#{prefix}, #{name}!"
     end
 
-    # Reserved word: user writes `or_`, macro registers as expression name `or`
-    defexpr or_(a, b) do
-      a || b
+    # Reserved word: user writes `not_`, macro registers as expression name `not`
+    defexpr not_(value) do
+      !value
     end
 
     # Variadic function
@@ -114,14 +114,14 @@ defmodule ExpressionDefexprTest do
   end
 
   describe "reserved words" do
-    test "or function works through defexpr" do
+    test "not function works through defexpr" do
       assert {:ok, true} =
-               Expression.evaluate("@(or(false, true))", %{}, DefexprCallbacks)
+               Expression.evaluate("@(not(false))", %{}, DefexprCallbacks)
     end
 
-    test "or with truthy first argument" do
-      assert {:ok, "yes"} =
-               Expression.evaluate(~s|@(or("yes", "no"))|, %{}, DefexprCallbacks)
+    test "not negates truthy value" do
+      assert {:ok, false} =
+               Expression.evaluate("@(not(true))", %{}, DefexprCallbacks)
     end
   end
 
@@ -185,7 +185,7 @@ defmodule ExpressionDefexprTest do
       assert :shout in names
       assert :add in names
       assert :greet in names
-      assert :or in names
+      assert :not in names
       assert :concat in names
     end
 

--- a/test/expression_defexpr_test.exs
+++ b/test/expression_defexpr_test.exs
@@ -32,9 +32,8 @@ defmodule ExpressionDefexprTest do
     # Variadic function
     @variadic true
     defexpr concat(args), ctx do
-      args
-      |> Enum.map(&Expression.Callbacks.EvalHelpers.eval!(&1, ctx))
-      |> Enum.join("")
+      alias Expression.Callbacks.EvalHelpers
+      Enum.map_join(args, "", &EvalHelpers.eval!(&1, ctx))
     end
   end
 
@@ -122,14 +121,14 @@ defmodule ExpressionDefexprTest do
 
     test "or with truthy first argument" do
       assert {:ok, "yes"} =
-               Expression.evaluate("@(or(\"yes\", \"no\"))", %{}, DefexprCallbacks)
+               Expression.evaluate(~s|@(or("yes", "no"))|, %{}, DefexprCallbacks)
     end
   end
 
   describe "@variadic" do
     test "variadic function receives argument list" do
       assert {:ok, "abc"} =
-               Expression.evaluate("@concat(\"a\", \"b\", \"c\")", %{}, DefexprCallbacks)
+               Expression.evaluate(~s|@concat("a", "b", "c")|, %{}, DefexprCallbacks)
     end
   end
 


### PR DESCRIPTION
## Summary

- Add `defexpr` macro for callback definition with automatic argument evaluation
- Add compile-time function registration and consistency validation
- Add `@variadic true` attribute support (replaces `_vargs` suffix convention)
- Add `use Expression.Callbacks` composition options (`stdlib:`, `also:`)

Depends on #321

## Details

**`defexpr` macro:** Two forms — `defexpr foo(a, b) do` (no context) and `defexpr foo(a, b), ctx do` (with context). Arguments are auto-evaluated from AST via generated `eval!` calls. Reserved words handled transparently: `defexpr or_(a, b)` registers as expression name `:or`.

**Compile-time infra:** `@expression_function` accumulated attribute with `validate_expression_func!/3` ensuring all clauses agree on context usage. `@before_compile` generates `__expression_functions__/0`. `@variadic` read at caller's compile time via `Module.delete_attribute` inside `quote` (Lua pattern).

**Composition:** `stdlib: false` disables Standard fallback. `also: [ModuleA, ModuleB]` for multi-module dispatch via `handle_chain/4`. Default `use Expression.Callbacks` behavior unchanged.

## Test plan

- [x] 21 new tests in `test/expression_defexpr_test.exs`
- [x] Expression: 558 doctests + 276 tests, 0 failures
- [x] Engage: 301 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)