### PR TITLE
[Callbacks] Guard against nil arguments to prevent Protocol.UndefinedError (PROD-5800)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: cla-assistant/github-action@v2.6.1
+        uses: cla-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,14 +33,14 @@ jobs:
         cache_version: ["3"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
       - name: Restore dependencies cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: mix-cache
         with:
           path: deps
@@ -58,7 +58,7 @@ jobs:
       - name: Credo
         run: mix credo --strict
       - name: Retrieve PLT Cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: plt_cache
         with:
           path: priv/plts
@@ -70,7 +70,7 @@ jobs:
         run: mix dialyzer --plt
       - name: Save PLT cache
         id: plt_cache_save
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: steps.plt_cache.outputs.cache-hit != 'true'
         with:
           key: |

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -17,18 +17,18 @@ jobs:
       contents: read
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.release.target_commitish }}
 
       - name: Setup BEAM
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
       - name: Restore dependencies cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: mix-cache
         with:
           path: deps

--- a/lib/expression/callbacks/standard.ex
+++ b/lib/expression/callbacks/standard.ex
@@ -1943,11 +1943,14 @@ defmodule Expression.Callbacks.Standard do
                   result: ["ing"]
   def regex_capture(ctx, binary, pattern) do
     [binary, pattern] = eval_args!([binary, pattern], ctx)
-    regex = Regex.compile!(pattern)
 
-    case Regex.run(regex, binary) do
-      nil -> nil
-      [_matched_text | captures] -> captures
+    if is_binary(binary) do
+      regex = Regex.compile!(pattern)
+
+      case Regex.run(regex, binary) do
+        nil -> nil
+        [_matched_text | captures] -> captures
+      end
     end
   end
 
@@ -1980,8 +1983,13 @@ defmodule Expression.Callbacks.Standard do
                   result: %{"match" => "ing"}
   def regex_named_capture(ctx, binary, pattern) do
     [binary, pattern] = eval_args!([binary, pattern], ctx)
-    regex = Regex.compile!(pattern)
-    Regex.named_captures(regex, binary) || %{}
+
+    if is_binary(binary) do
+      regex = Regex.compile!(pattern)
+      Regex.named_captures(regex, binary) || %{}
+    else
+      %{}
+    end
   end
 
   @doc """
@@ -2015,9 +2023,13 @@ defmodule Expression.Callbacks.Standard do
   def with_index(ctx, enumerable) do
     [enumerable] = eval_args!([enumerable], ctx)
 
-    enumerable
-    |> Enum.with_index()
-    |> Enum.map(fn {element, index} -> [element, index] end)
+    if is_nil(enumerable) or is_nil(Enumerable.impl_for(enumerable)) do
+      []
+    else
+      enumerable
+      |> Enum.with_index()
+      |> Enum.map(fn {element, index} -> [element, index] end)
+    end
   end
 
   @doc """
@@ -2360,7 +2372,12 @@ defmodule Expression.Callbacks.Standard do
                   result: true
   def has_all_members(ctx, list, items) do
     [list, items] = eval_args!([list, items], ctx)
-    Enum.all?(items, &Enum.member?(list, &1))
+
+    if is_list(list) and is_list(items) do
+      Enum.all?(items, &Enum.member?(list, &1))
+    else
+      false
+    end
   end
 
   @doc """
@@ -2492,7 +2509,12 @@ defmodule Expression.Callbacks.Standard do
                   result: true
   def has_any_member(ctx, list, items) do
     [list, items] = eval_args!([list, items], ctx)
-    Enum.any?(items, &Enum.member?(list, &1))
+
+    if is_list(list) and is_list(items) do
+      Enum.any?(items, &Enum.member?(list, &1))
+    else
+      false
+    end
   end
 
   @expression_category "string"
@@ -2732,7 +2754,11 @@ defmodule Expression.Callbacks.Standard do
   def uniq(ctx, enumerable) do
     [enumerable] = eval_args!([enumerable], ctx)
 
-    Enum.uniq(enumerable)
+    if is_nil(enumerable) or is_nil(Enumerable.impl_for(enumerable)) do
+      []
+    else
+      Enum.uniq(enumerable)
+    end
   end
 
   @doc """
@@ -2800,6 +2826,7 @@ defmodule Expression.Callbacks.Standard do
 
     if is_binary(haystack) do
       [words] = eval_args!([words], ctx)
+      words = to_string(words)
       haystack_words = String.split(haystack)
       haystacks_lowercase = Enum.map(haystack_words, &String.downcase/1)
       words_lowercase = words |> String.split() |> Enum.map(&String.downcase/1)
@@ -2856,12 +2883,17 @@ defmodule Expression.Callbacks.Standard do
     [text, phrases] = eval_args!([text, phrases], ctx)
 
     phrases =
-      if is_binary(phrases) do
-        phrases
-        |> String.split(",")
-        |> Enum.map(&String.trim/1)
-      else
-        phrases
+      cond do
+        is_binary(phrases) ->
+          phrases
+          |> String.split(",")
+          |> Enum.map(&String.trim/1)
+
+        is_list(phrases) ->
+          phrases
+
+        true ->
+          []
       end
 
     String.contains?(

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -64,6 +64,36 @@ defmodule ExpressionTest do
       assert false ==
                Expression.evaluate_as_boolean!("@has_only_phrase(name, 'bar')", %{"name" => nil})
 
+      assert false ==
+               Expression.evaluate_as_boolean!(
+                 "@has_any_phrase('hello', phrases)",
+                 %{"phrases" => nil}
+               )
+
+      assert false ==
+               Expression.evaluate_as_boolean!(
+                 "@has_all_members(list, items)",
+                 %{"list" => nil, "items" => ["a"]}
+               )
+
+      assert false ==
+               Expression.evaluate_as_boolean!(
+                 "@has_all_members(list, items)",
+                 %{"list" => ["a"], "items" => nil}
+               )
+
+      assert false ==
+               Expression.evaluate_as_boolean!(
+                 "@has_any_member(list, items)",
+                 %{"list" => nil, "items" => ["a"]}
+               )
+
+      assert false ==
+               Expression.evaluate_as_boolean!(
+                 "@has_any_member(list, items)",
+                 %{"list" => ["a"], "items" => nil}
+               )
+
       assert true ==
                Expression.evaluate_as_boolean!("@has_beginning(contact.number, \"123\")", %{
                  "contact" => %{"number" => 123_456}
@@ -706,6 +736,36 @@ defmodule ExpressionTest do
         expected_string_result: "",
         context: %{}
       )
+    end
+  end
+
+  describe "nil safety for callbacks" do
+    test "with_index returns empty list for nil" do
+      assert [] == Expression.evaluate!("@with_index(items)", %{"items" => nil})
+    end
+
+    test "uniq returns empty list for nil" do
+      assert [] == Expression.evaluate!("@uniq(items)", %{"items" => nil})
+    end
+
+    test "regex_capture returns nil for nil input" do
+      assert nil == Expression.evaluate!("@regex_capture(text, \"test(.+)\")", %{"text" => nil})
+    end
+
+    test "regex_named_capture returns empty map for nil input" do
+      assert %{} ==
+               Expression.evaluate!(
+                 "@regex_named_capture(text, \"test(?P<match>.+)\")",
+                 %{"text" => nil}
+               )
+    end
+
+    test "has_any_word returns false for nil words" do
+      assert false ==
+               Expression.evaluate_as_boolean!(
+                 "@has_any_word('hello world', words)",
+                 %{"words" => nil}
+               )
     end
   end
 end


### PR DESCRIPTION
## Purpose

Several callback functions in `Expression.Callbacks.Standard` crash with `Protocol.UndefinedError` when arguments resolve to `nil` at runtime. This happens in journey expressions when users reference unset contact fields or variables that evaluate to `nil`.

The original crash was `Enum.map(nil, ...)` inside `has_any_phrase/3`, but an audit revealed 7 additional functions with the same vulnerability.

### Link to the story

PROD-5800

## Approach

Added type guards to 8 callback functions, following the same pattern already used by safe sibling functions (`filter`, `find`, `map`, `reduce`, `reject`, `sort_by`):

| Function | Guard | Nil behavior |
|---|---|---|
| `has_any_phrase/3` | `cond` with `is_binary`/`is_list`/fallback | returns `false` |
| `has_all_members/3` | `is_list(list) and is_list(items)` | returns `false` |
| `has_any_member/3` | `is_list(list) and is_list(items)` | returns `false` |
| `has_any_word/3` | `to_string(words)` before `String.split` | returns `false` |
| `with_index/2` | `is_nil \|\| !Enumerable.impl_for` | returns `[]` |
| `uniq/2` | `is_nil \|\| !Enumerable.impl_for` | returns `[]` |
| `regex_capture/3` | `is_binary(binary)` | returns `nil` |
| `regex_named_capture/3` | `is_binary(binary)` | returns `%{}` |

## Security & Privacy

No security or privacy impact. This change only adds defensive guards that prevent crashes — no new data access or exposure.

## Learning

Followed the existing nil-guard patterns in the codebase (e.g. `filter/3` at line 591) for consistency.
