### PR TITLE
Stringify Time structs as ISO8601 in both engines (PROD-5951)

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -30,7 +30,7 @@ jobs:
             otp: "28"
             check_formatting: true
         # when updating this, please also see ./releases.yml
-        cache_version: ["3"]
+        cache_version: ["4"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,7 +8,7 @@ env:
   ELIXIR_VERSION: "1.19"
   OTP_VERSION: "28"
   # when updating this, please also see ./elixir.yml
-  CACHE_VERSION: "3"
+  CACHE_VERSION: "4"
 
 jobs:
   publish:

--- a/lib/expression.ex
+++ b/lib/expression.ex
@@ -43,6 +43,7 @@ defmodule Expression do
           | map
           | DateTime.t()
           | Date.t()
+          | Time.t()
 
   alias Expression.Context
   alias Expression.Eval
@@ -194,6 +195,7 @@ defmodule Expression do
   def stringify(binary) when is_binary(binary), do: binary
   def stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)
   def stringify(%Date{} = date), do: Date.to_iso8601(date)
+  def stringify(%Time{} = time), do: Time.to_iso8601(time)
   def stringify(map) when is_map(map), do: "#{inspect(map)}"
   def stringify(other), do: to_string(other)
 

--- a/lib/expression/v2.ex
+++ b/lib/expression/v2.ex
@@ -220,6 +220,7 @@ defmodule Expression.V2 do
   def stringify(binary) when is_binary(binary), do: binary
   def stringify(%DateTime{} = date), do: DateTime.to_iso8601(date)
   def stringify(%Date{} = date), do: Date.to_iso8601(date)
+  def stringify(%Time{} = time), do: Time.to_iso8601(time)
   def stringify(map) when is_map(map), do: "#{inspect(map)}"
   def stringify(other), do: to_string(other)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "2.49.0"
+  @version "2.49.1"
 
   def project do
     [

--- a/test/expression/v2/eval_test.exs
+++ b/test/expression/v2/eval_test.exs
@@ -41,13 +41,26 @@ defmodule Expression.V2.EvalTest do
 
   describe "eval_as_string" do
     test "with missing vars" do
-      assert "hello @one.two.three" == Expression.V2.eval_as_string("hello @one.two.three")
+      assert "hello @one.two.three" == V2.eval_as_string("hello @one.two.three")
+    end
+
+    test "stringifies a time reached via context substitution" do
+      assert "11:00:00" ==
+               V2.eval_as_string("@appointment", Context.new(%{"appointment" => ~T[11:00:00]}))
+    end
+
+    test "stringifies a time embedded in surrounding text" do
+      assert "Your slot is 11:00:00 today" ==
+               V2.eval_as_string(
+                 "Your slot is @appointment today",
+                 Context.new(%{"appointment" => ~T[11:00:00]})
+               )
     end
   end
 
   describe "eval" do
     test "with missing vars" do
-      assert nil == Expression.V2.eval_block("one.two.three")
+      assert nil == V2.eval_block("one.two.three")
     end
 
     test "vars" do

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -249,6 +249,19 @@ defmodule ExpressionTest do
                Expression.evaluate_as_string!(~T[11:00:00])
     end
 
+    test "stringify time reached via context substitution" do
+      assert "11:00:00" ==
+               Expression.evaluate_as_string!("@appointment", %{"appointment" => ~T[11:00:00]})
+    end
+
+    test "stringify time embedded in surrounding text" do
+      assert "Your slot is 11:00:00 today" ==
+               Expression.evaluate_as_string!(
+                 "Your slot is @appointment today",
+                 %{"appointment" => ~T[11:00:00]}
+               )
+    end
+
     test "list with out of bound indicess" do
       assert nil ==
                Expression.evaluate!("@foo[cursor]", %{"foo" => ["baz", "bar"], "cursor" => 100})


### PR DESCRIPTION
## Why

When a `Time` value reaches interpolated text, e.g. the result of `timevalue(...)`, it rendered as the raw inspected struct `~T[09:00:00]` instead of `09:00:00` ([the value expected by the documentation](https://whatsapp.turn.io/docs/journeys/expressions_reference#timevalueexpression)). 

Root cause: `stringify/1` (the value→string step in `eval_as_string`) has explicit clauses for `Date` and `DateTime` but none for `Time`. A `Time` struct is a map, so it fell through to the generic `def stringify(map) when is_map(map), do: inspect(map)` clause.

## What

- Add `def stringify(%Time{} = time), do: Time.to_iso8601(time)` to both engines, beside the existing `Date`/`DateTime` clauses.

## Notes

- A pre-existing ["Stringify time sigil" test](https://github.com/turnhub/expression/blob/53e45cd07ab66d0465d4bd65645d8a8dc135fd16/test/expression_test.exs#L247-L250) only covered a `Time` passed directly as the whole expression, a different code path that already worked, which masked this. The broken case is a context-substituted / callback-produced `Time`.
