### PR TITLE
Bump README install version to 2.49.1 to match the release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 2.49.0"}
+    {:expression, "~> 2.49.1"}
   ]
 end
 ```


### PR DESCRIPTION
## Why

The Hex release workflow's **"Verify versions match release tag"** step compares both `mix.exs` and the README install snippet against the release tag, and aborts the publish if either differs. The 2.49.1 release (#344) bumped `mix.exs` to 2.49.1 but left the README install snippet at `~> 2.49.0`, so the guard failed and 2.49.1 never reached Hex.

## What

Bump the README install snippet to `~> 2.49.1` so both versions match the tag and the release can publish.

Ref: PROD-5951
