### PR TITLE
fix: parse identifiers with leading underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v3.0.0-rc.3
+
+### Fixed
+
+- Identifiers may now start with underscores, so attribute access on
+  WhatsApp webhook vendor keys such as `@event.message._vnd.v1.chat`
+  parses fully instead of stopping at the underscore. A bare `_` is
+  still not an identifier: `@(_)` remains literal text, and unresolved
+  variables like `@_missing` render back as-is.
+
 ## v3.0.0-rc.0
 
 This is the first release candidate for v3.0.0. It contains the breaking

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ by adding `expression` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:expression, "~> 3.0.0-rc.2"}
+    {:expression, "~> 3.0.0-rc.3"}
   ]
 end
 ```

--- a/lib/expression/parser.ex
+++ b/lib/expression/parser.ex
@@ -37,7 +37,8 @@ defmodule Expression.Parser do
 
   # atom = atom
   atom =
-    ascii_string([?a..?z, ?A..?Z, ?0..?9], min: 1)
+    ascii_string([?_], min: 0)
+    |> ascii_string([?a..?z, ?A..?Z, ?0..?9], min: 1)
     |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_, ?-], min: 0)
     |> map({String, :downcase, []})
     |> reduce({Enum, :join, []})

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Expression.MixProject do
   use Mix.Project
 
-  @version "3.0.0-rc.2"
+  @version "3.0.0-rc.3"
 
   def project do
     [

--- a/test/expression/parser_test.exs
+++ b/test/expression/parser_test.exs
@@ -10,6 +10,11 @@ defmodule Expression.ParserTest do
     assert_ast([expression: [atom: "foo"]], "@foo")
   end
 
+  test "expression with a leading underscore" do
+    assert_ast([expression: [atom: "_foo"]], "@_foo")
+    assert_ast([expression: [atom: "__foo"]], "@__foo")
+  end
+
   test "escaped at" do
     assert_ast([text: "user", text: "@", text: "example.org"], "user@@example.org")
   end
@@ -422,6 +427,31 @@ defmodule Expression.ParserTest do
           ]
         ],
         "@foo.bar.baz"
+      )
+    end
+
+    test "on keys with leading underscores" do
+      assert_ast(
+        [
+          expression: [
+            attribute: [
+              attribute: [
+                attribute: [
+                  attribute: [atom: "event", atom: "message"],
+                  atom: "_vnd"
+                ],
+                atom: "v1"
+              ],
+              atom: "chat"
+            ]
+          ]
+        ],
+        "@event.message._vnd.v1.chat"
+      )
+
+      assert_ast(
+        [expression: [attribute: [atom: "foo", atom: "_bar"]]],
+        "@(foo._bar)"
       )
     end
 

--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -197,6 +197,23 @@ defmodule ExpressionTest do
       assert "bar" == Expression.evaluate_as_string!("@foo[1]", %{"foo" => ["baz", "bar"]})
     end
 
+    test "attributes with leading underscores" do
+      context = %{
+        "event" => %{
+          "message" => %{"_vnd" => %{"v1" => %{"chat" => %{"state" => "OPEN"}}}}
+        }
+      }
+
+      assert Expression.evaluate_as_string!("@event.message._vnd.v1.chat.state", context) ==
+               "OPEN"
+
+      assert Expression.evaluate_block!("event.message._vnd.v1.chat", context) == %{
+               "state" => "OPEN"
+             }
+
+      assert Expression.evaluate_as_string!("@_missing", %{}) == "@_missing"
+    end
+
     test "list with variable" do
       assert "bar" =
                Expression.evaluate_as_string!("@foo[cursor]", %{


### PR DESCRIPTION
## Problem

Some payloads may have keys that start with an underscore, such as `_vnd`. Expressions traversing them stop parsing at the underscore:

```elixir
Expression.evaluate_as_string!("@event.message._vnd.v1.chat", context)
# => "%{\"_vnd\" => %{...}}._vnd.v1.chat"
#    (the inspected message map, then the rest as literal text)
```

The `atom` combinator in `Expression.Parser` requires the first character of an identifier to be a letter or digit, so `._vnd` fails the attribute parse, and the expression is truncated after `event.message`.

## Fix

Allow leading underscores in the atom grammar while still requiring at least one letter or digit, so a bare `_` keeps failing to parse.

```elixir
atom =
  ascii_string([?_], min: 0)
  |> ascii_string([?a..?z, ?A..?Z, ?0..?9], min: 1)
  |> ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_, ?-], min: 0)
```

## Behavior changes

| Input | Before | After |
| --- | --- | --- |
| `@event.message._vnd.v1.chat` | truncated after `event.message`, tail rendered as literal text | resolves the full chain |
| `@_missing` (not in context) | rendered `_missing` — the `@` was silently swallowed by an empty expression match | rendered `@_missing`, the documented round-trip for unresolved variables |
| `@(_)` | literal, no expression parsed | unchanged |

The `@(_)` row matters: keeping the `min: 1` letter-or-digit requirement is what stops a bare underscore becoming an identifier, so the existing guard test stays green and Elixir's "underscore means unused" convention doesn't bleed into map keys.

This supersedes #369, which was closed unmerged while still a draft.